### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Sprout, LogOut, User } from 'lucide-react';
+import ThemeToggle from './ThemeToggle';
 import { useAuth } from '@/hooks/useAuth';
 import { Link } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
@@ -47,9 +48,13 @@ const Header = () => {
   };
 
   return (
-    <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-      isScrolled ? 'bg-white/95 backdrop-blur-sm shadow-lg' : 'bg-transparent'
-    }`}>
+    <header
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
+        isScrolled
+          ? 'bg-white/95 dark:bg-slate-900/90 backdrop-blur-sm shadow-lg'
+          : 'bg-transparent'
+      }`}
+    >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16 lg:h-20">
           {/* Logo */}
@@ -105,6 +110,7 @@ const Header = () => {
                 </Button>
               </div>
             )}
+            <ThemeToggle />
           </div>
 
           {/* Mobile Menu Button */}
@@ -164,6 +170,7 @@ const Header = () => {
                     </Button>
                   </div>
                 )}
+                <ThemeToggle />
               </div>
             </nav>
           </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Sun, Moon } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { Button } from '@/components/ui/button'
+
+const ThemeToggle = () => {
+  const { theme, setTheme } = useTheme()
+
+  const isDark = theme === 'dark'
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+    >
+      {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </Button>
+  )
+}
+
+export default ThemeToggle

--- a/src/index.css
+++ b/src/index.css
@@ -66,6 +66,8 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
+    --cream: 222.2 84% 4.9%;
+    --slate-gray: 210 40% 98%;
   }
 }
 
@@ -75,7 +77,7 @@
   }
   
   body {
-    @apply bg-cream text-slate-gray font-inter;
+    @apply bg-cream text-slate-gray font-inter dark:bg-background dark:text-foreground;
     background-color: hsl(var(--cream));
     color: hsl(var(--slate-gray));
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { ThemeProvider } from 'next-themes'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider attribute="class" defaultTheme="light">
+    <App />
+  </ThemeProvider>
+);


### PR DESCRIPTION
## Summary
- implement ThemeProvider and add dark theme color variables
- create ThemeToggle component with sun/moon icon
- integrate ThemeToggle into header

## Testing
- `npm run lint` *(fails: Unexpected any & other lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d01673e908324a0e58cae93bbccd8