### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -27,7 +27,7 @@ const About = () => {
   ];
 
   return (
-    <section id="about" className="py-20 bg-sage/5">
+    <section id="about" className="py-20 bg-sage/5 dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center mb-16">
@@ -40,7 +40,7 @@ const About = () => {
         </div>
 
         {/* Mission Statement */}
-        <div className="bg-white rounded-2xl p-8 sm:p-12 mb-16 shadow-lg">
+        <div className="bg-white dark:bg-slate-900 rounded-2xl p-8 sm:p-12 mb-16 shadow-lg">
           <div className="max-w-4xl mx-auto text-center">
             <h3 className="text-2xl sm:text-3xl font-bold text-forest-green mb-6">Our Mission</h3>
             <p className="text-lg text-slate-gray leading-relaxed mb-8">
@@ -89,7 +89,7 @@ const About = () => {
         </div>
 
         {/* Target Market */}
-        <div className="bg-white rounded-2xl p-8 sm:p-12 shadow-lg">
+        <div className="bg-white dark:bg-slate-900 rounded-2xl p-8 sm:p-12 shadow-lg">
           <div className="max-w-4xl mx-auto">
             <h3 className="text-2xl sm:text-3xl font-bold text-forest-green text-center mb-8">
               Who We Serve

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -50,10 +50,11 @@ const Contact = () => {
         message: '',
         serviceType: ''
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Please try again later.";
       toast({
         title: "Failed to send message",
-        description: error.message || "Please try again later.",
+        description: message,
         variant: "destructive",
       });
     } finally {
@@ -80,10 +81,11 @@ const Contact = () => {
       });
 
       setNewsletterEmail('');
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Please try again later.";
       toast({
         title: "Subscription failed",
-        description: error.message || "Please try again later.",
+        description: message,
         variant: "destructive",
       });
     } finally {
@@ -99,7 +101,7 @@ const Contact = () => {
   };
 
   return (
-    <section id="contact" className="py-20 bg-sage/5">
+    <section id="contact" className="py-20 bg-sage/5 dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center mb-16">
@@ -197,7 +199,7 @@ const Contact = () => {
           {/* Contact Information & CTA */}
           <div className="space-y-8">
             {/* Contact Details */}
-            <Card className="border-sage/30 shadow-lg">
+            <Card className="border-sage/30 dark:bg-slate-900 shadow-lg">
               <CardContent className="p-8">
                 <h3 className="text-xl font-semibold text-forest-green mb-6">Get in Touch</h3>
                 <div className="space-y-4">
@@ -233,7 +235,7 @@ const Contact = () => {
             </Card>
 
             {/* Schedule a Workshop */}
-            <Card className="border-forest-green/30 bg-forest-green/5 shadow-lg">
+            <Card className="border-forest-green/30 bg-forest-green/5 dark:bg-slate-900 shadow-lg">
               <CardContent className="p-8 text-center">
                 <h3 className="text-xl font-semibold text-forest-green mb-4">
                   Ready for a Workshop?

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-slate-gray text-cream py-12">
+    <footer className="bg-slate-gray dark:bg-slate-900 text-cream py-12">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Brand Section */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Sprout, LogOut, User } from 'lucide-react';
+import ThemeToggle from './ThemeToggle';
 import { useAuth } from '@/hooks/useAuth';
 import { Link } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
@@ -47,9 +48,13 @@ const Header = () => {
   };
 
   return (
-    <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-      isScrolled ? 'bg-white/95 backdrop-blur-sm shadow-lg' : 'bg-transparent'
-    }`}>
+    <header
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
+        isScrolled
+          ? 'bg-white/95 dark:bg-slate-900/90 backdrop-blur-sm shadow-lg'
+          : 'bg-transparent'
+      }`}
+    >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16 lg:h-20">
           {/* Logo */}
@@ -68,7 +73,7 @@ const Header = () => {
               <a
                 key={item.name}
                 href={item.href}
-                className="text-slate-gray hover:text-forest-green transition-colors duration-200 font-medium"
+                className="text-slate-gray dark:text-cream hover:text-forest-green transition-colors duration-200 font-medium"
               >
                 {item.name}
               </a>
@@ -79,7 +84,7 @@ const Header = () => {
           <div className="hidden md:flex items-center space-x-4">
             {user ? (
               <div className="flex items-center space-x-3">
-                <div className="flex items-center space-x-2 text-slate-gray">
+                <div className="flex items-center space-x-2 text-slate-gray dark:text-cream">
                   <User className="w-4 h-4" />
                   <span className="text-sm">{user.email}</span>
                 </div>
@@ -96,7 +101,7 @@ const Header = () => {
             ) : (
               <div className="flex items-center space-x-3">
                 <Link to="/auth">
-                  <Button variant="outline" className="border-sage hover:bg-sage/20">
+                  <Button variant="outline" className="border-sage hover:bg-sage/20 dark:text-cream">
                     Sign In
                   </Button>
                 </Link>
@@ -105,32 +110,36 @@ const Header = () => {
                 </Button>
               </div>
             )}
+            <ThemeToggle />
           </div>
 
-          {/* Mobile Menu Button */}
-          <button
-            className="md:hidden p-2 text-slate-gray hover:text-forest-green transition-colors"
-            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              {isMobileMenuOpen ? (
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              ) : (
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-              )}
-            </svg>
-          </button>
+          {/* Mobile actions */}
+          <div className="md:hidden flex items-center space-x-2">
+            <ThemeToggle />
+            <button
+              className="p-2 text-slate-gray dark:text-cream hover:text-forest-green transition-colors"
+              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                {isMobileMenuOpen ? (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                )}
+              </svg>
+            </button>
+          </div>
         </div>
 
         {/* Mobile Menu */}
         {isMobileMenuOpen && (
-          <div className="md:hidden bg-white border-t border-sage/20 py-4 animate-fade-in">
+          <div className="md:hidden bg-white dark:bg-slate-900 border-t border-sage/20 dark:border-sage/50 py-4 animate-fade-in">
             <nav className="flex flex-col space-y-4">
               {navItems.map((item) => (
                 <a
                   key={item.name}
                   href={item.href}
-                  className="text-slate-gray hover:text-forest-green transition-colors duration-200 font-medium px-4 py-2"
+                  className="text-slate-gray dark:text-cream hover:text-forest-green transition-colors duration-200 font-medium px-4 py-2"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   {item.name}
@@ -139,7 +148,7 @@ const Header = () => {
               <div className="px-4 pt-2 space-y-2">
                 {user ? (
                   <div className="space-y-2">
-                    <div className="flex items-center space-x-2 text-slate-gray text-sm">
+                    <div className="flex items-center space-x-2 text-slate-gray dark:text-cream text-sm">
                       <User className="w-4 h-4" />
                       <span>{user.email}</span>
                     </div>
@@ -155,7 +164,7 @@ const Header = () => {
                 ) : (
                   <div className="space-y-2">
                     <Link to="/auth">
-                      <Button variant="outline" className="w-full border-sage hover:bg-sage/20">
+                      <Button variant="outline" className="w-full border-sage hover:bg-sage/20 dark:text-cream">
                         Sign In
                       </Button>
                     </Link>
@@ -164,6 +173,7 @@ const Header = () => {
                     </Button>
                   </div>
                 )}
+                <ThemeToggle />
               </div>
             </nav>
           </div>

--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -40,7 +40,7 @@ const Reviews = () => {
   };
 
   return (
-    <section id="reviews" className="py-20 bg-cream">
+    <section id="reviews" className="py-20 bg-cream dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center mb-16 animate-fade-in-up">
@@ -55,7 +55,7 @@ const Reviews = () => {
         {/* Testimonials Grid */}
         <div className="grid md:grid-cols-3 gap-8 mb-16">
           {testimonials.map((testimonial, index) => (
-            <Card key={index} className="bg-white shadow-lg hover:shadow-xl transition-all duration-300 border-0 animate-fade-in-up" style={{ animationDelay: `${index * 0.2}s` }}>
+            <Card key={index} className="bg-white dark:bg-slate-900 shadow-lg hover:shadow-xl transition-all duration-300 border-0 animate-fade-in-up" style={{ animationDelay: `${index * 0.2}s` }}>
               <CardContent className="p-8">
                 {/* Quote Icon */}
                 <div className="text-sage text-6xl font-serif mb-4 leading-none">"</div>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -56,7 +56,7 @@ const Services = () => {
   ];
 
   return (
-    <section id="services" className="py-20 bg-white">
+    <section id="services" className="py-20 bg-white dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center mb-16">
@@ -106,7 +106,7 @@ const Services = () => {
         </div>
 
         {/* CTA Section */}
-        <div className="text-center bg-sage/10 rounded-2xl p-8 sm:p-12">
+        <div className="text-center bg-sage/10 dark:bg-slate-900 rounded-2xl p-8 sm:p-12">
           <h3 className="text-2xl sm:text-3xl font-bold text-forest-green mb-4">
             Ready to Transform Your Business?
           </h3>

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -44,7 +44,7 @@ const Team = () => {
   ];
 
   return (
-    <section id="team" className="py-20 bg-white">
+    <section id="team" className="py-20 bg-white dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
         <div className="text-center mb-16">
@@ -126,7 +126,7 @@ const Team = () => {
         </div>
 
         {/* Team Philosophy */}
-        <div className="mt-16 bg-sage/5 rounded-2xl p-8 sm:p-12 text-center">
+        <div className="mt-16 bg-sage/5 dark:bg-slate-900 rounded-2xl p-8 sm:p-12 text-center">
           <h3 className="text-2xl sm:text-3xl font-bold text-forest-green mb-6">
             Our Approach
           </h3>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Sun, Moon } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { Button } from '@/components/ui/button'
+
+const ThemeToggle = () => {
+  const { theme, setTheme } = useTheme()
+
+  const isDark = theme === 'dark'
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+    >
+      {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </Button>
+  )
+}
+
+export default ThemeToggle

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,9 @@
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 /* Custom color variables for RootedAI brand */
 @layer base {
@@ -66,6 +66,8 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
+    --cream: 222.2 84% 4.9%;
+    --slate-gray: 210 40% 98%;
   }
 }
 
@@ -75,7 +77,7 @@
   }
   
   body {
-    @apply bg-cream text-slate-gray font-inter;
+    @apply bg-cream text-slate-gray font-inter dark:bg-background dark:text-foreground;
     background-color: hsl(var(--cream));
     color: hsl(var(--slate-gray));
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { ThemeProvider } from 'next-themes'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider attribute="class" defaultTheme="light">
+    <App />
+  </ThemeProvider>
+);

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -95,7 +95,7 @@ const Auth = () => {
           });
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         title: "Error",
         description: "An unexpected error occurred. Please try again.",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -122,5 +123,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- implement dark mode styles for site containers
- keep theme toggle visible on mobile and style navigation links
- allow async error handling without `any` types
- fix Tailwind config for ESM
- reorder CSS imports for build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d01673e908324a0e58cae93bbccd8