### PR TITLE
Fix service worker registration paths

### DIFF
--- a/src/hooks/useAIJokes.tsx
+++ b/src/hooks/useAIJokes.tsx
@@ -30,7 +30,7 @@ export const useAIJokes = () => {
     if ('serviceWorker' in navigator) {
       try {
         const registration = await navigator.serviceWorker.register(
-          new URL('sw.js', import.meta.env.BASE_URL)
+          `${import.meta.env.BASE_URL}sw.js`
         );
         setServiceWorkerRegistration(registration);
         console.log('Service Worker registered successfully');

--- a/src/hooks/usePWAUpdate.tsx
+++ b/src/hooks/usePWAUpdate.tsx
@@ -22,9 +22,9 @@ export const usePWAUpdate = (): PWAUpdateHook => {
 
   useEffect(() => {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.getRegistration(
-        new URL('sw.js', import.meta.env.BASE_URL)
-      ).then((reg) => {
+      navigator.serviceWorker
+        .getRegistration(`${import.meta.env.BASE_URL}sw.js`)
+        .then((reg) => {
         if (reg) {
           setRegistration(reg);
           


### PR DESCRIPTION
## Summary
- fix service worker registration URLs so PWA loads correctly

## Testing
- `npm run build`
- `npm run lint` *(fails: no-case-declarations and @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_687d783868ac8324bcb1b03fbf32b250