### PR TITLE
Add admin role and page with debug toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/hooks/useAuth";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
+import Admin from "./pages/Admin";
 import NotFound from "./pages/NotFound";
 import VapidSetup from "./pages/VapidSetup";
 
@@ -24,6 +25,7 @@ const App = () => {
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/auth" element={<Auth />} />
+              <Route path="/admin" element={<Admin />} />
               <Route path="/vapid-setup" element={<VapidSetup />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ const Header = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [showInstallDialog, setShowInstallDialog] = useState(false);
-  const { user, signOut } = useAuth();
+  const { user, profile, signOut } = useAuth();
   const { isInstallable, isInstalled, installApp } = usePWAInstall();
   const { toast } = useToast();
 
@@ -82,6 +82,14 @@ const Header = () => {
                 {item.name}
               </a>
             ))}
+            {profile?.role === 'admin' && (
+              <Link
+                to="/admin"
+                className="text-slate-gray dark:text-white hover:text-forest-green transition-colors duration-200 font-medium"
+              >
+                Admin
+              </Link>
+            )}
           </nav>
 
           {/* CTA Button / Auth */}
@@ -166,16 +174,25 @@ const Header = () => {
         {isMobileMenuOpen && (
           <div className="md:hidden bg-white dark:bg-slate-900 border-t border-sage/20 dark:border-sage/50 py-4 animate-fade-in">
             <nav className="flex flex-col space-y-4">
-              {navItems.map((item) => (
-                <a
-                  key={item.name}
-                  href={item.href}
-                  className="text-slate-gray dark:text-white hover:text-forest-green dark:hover:text-white/80 transition-colors duration-200 font-medium px-4 py-2"
-                  onClick={() => setIsMobileMenuOpen(false)}
-                >
-                  {item.name}
-                </a>
-              ))}
+            {navItems.map((item) => (
+              <a
+                key={item.name}
+                href={item.href}
+                className="text-slate-gray dark:text-white hover:text-forest-green dark:hover:text-white/80 transition-colors duration-200 font-medium px-4 py-2"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                {item.name}
+              </a>
+            ))}
+            {profile?.role === 'admin' && (
+              <Link
+                to="/admin"
+                className="text-slate-gray dark:text-white hover:text-forest-green dark:hover:text-white/80 transition-colors duration-200 font-medium px-4 py-2"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Admin
+              </Link>
+            )}
               <div className="px-4 pt-2 space-y-2">
                 {user ? (
                   <div className="space-y-2">

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, createContext, useContext } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import type { User, Session } from '@supabase/supabase-js';
+import type { Tables } from '@/integrations/supabase/types';
 
 interface AuthContextType {
   user: User | null;
   session: Session | null;
+  profile: Tables<'profiles'> | null;
   loading: boolean;
   signOut: () => Promise<void>;
 }
@@ -14,7 +16,21 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
+  const [profile, setProfile] = useState<Tables<'profiles'> | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const fetchProfile = async (userId: string) => {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (!error) {
+      setProfile(data);
+    } else {
+      console.error('Error fetching profile:', error);
+    }
+  };
 
   useEffect(() => {
     // Set up auth state listener
@@ -22,6 +38,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       (event, session) => {
         setSession(session);
         setUser(session?.user ?? null);
+        if (session?.user) {
+          fetchProfile(session.user.id);
+        } else {
+          setProfile(null);
+        }
         setLoading(false);
       }
     );
@@ -30,6 +51,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
       setUser(session?.user ?? null);
+      if (session?.user) {
+        fetchProfile(session.user.id);
+      }
       setLoading(false);
     });
 
@@ -46,6 +70,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const value = {
     user,
     session,
+    profile,
     loading,
     signOut,
   };

--- a/src/hooks/useAuthFix.tsx
+++ b/src/hooks/useAuthFix.tsx
@@ -30,7 +30,8 @@ export const useAuthFix = () => {
             .insert({
               user_id: user.id,
               full_name: user.email,
-              email: user.email
+              email: user.email,
+              role: 'client'
             });
 
           if (insertError) {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -100,6 +100,7 @@ export type Database = {
           id: string
           updated_at: string
           user_id: string
+          role: string
         }
         Insert: {
           created_at?: string
@@ -108,6 +109,7 @@ export type Database = {
           id?: string
           updated_at?: string
           user_id: string
+          role?: string
         }
         Update: {
           created_at?: string
@@ -116,6 +118,7 @@ export type Database = {
           id?: string
           updated_at?: string
           user_id?: string
+          role?: string
         }
         Relationships: []
       }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import { useAuth } from '@/hooks/useAuth';
+import { NotificationDebugger } from '@/components/NotificationDebugger';
+import { Button } from '@/components/ui/button';
+import NotFound from './NotFound';
+
+const Admin = () => {
+  const { user, profile, loading } = useAuth();
+  const [showStats, setShowStats] = useState(false);
+
+  if (loading) return null;
+
+  if (!user || profile?.role !== 'admin') {
+    return <NotFound />;
+  }
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <main className="py-16">
+        <div className="container mx-auto px-4 space-y-6">
+          <h1 className="text-3xl font-bold text-forest-green mb-4">Admin Dashboard</h1>
+          <p className="text-slate-gray">
+            Welcome, {profile?.full_name || user.email}! This page is only visible to administrators.
+          </p>
+
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold">Admin Controls</h2>
+            <Button onClick={() => setShowStats((s) => !s)} variant="outline" size="sm">
+              {showStats ? 'Hide Debug Stats' : 'Show Debug Stats'}
+            </Button>
+            {showStats && (
+              <div className="pt-4">
+                <NotificationDebugger />
+              </div>
+            )}
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Admin;

--- a/supabase/migrations/20250725120000-db11c8b3-70cf-480d-af8d-2f9810f03fbc.sql
+++ b/supabase/migrations/20250725120000-db11c8b3-70cf-480d-af8d-2f9810f03fbc.sql
@@ -1,0 +1,31 @@
+-- Add role column to profiles table
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'client';
+
+-- Update profile creation trigger to include role
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO public.profiles (user_id, full_name, email, role)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data ->> 'full_name', NEW.email),
+    NEW.email,
+    'client'
+  );
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Assign admin role to james@hennahane.com
+UPDATE public.profiles
+SET role = 'admin'
+WHERE email = 'james@hennahane.com';


### PR DESCRIPTION
## Summary
- add admin link in the header for admin users
- show admin link in mobile menu when profile role is admin
- keep profile info in auth context
- create admin page with controls to toggle push notification debug stats
- ensure default client role when creating profiles

## Testing
- `npm run lint` *(fails: 14 errors, 12 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d95fdcc888324a52fb8651499a38e