### PR TITLE
Add PWA splash screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
   </head>
 
   <body>
+    <div id="splash-screen">
+      <img src="/lovable-uploads/22badab3-8f25-475f-92d7-167cbc732868.png" alt="RootedAI logo" />
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/index.css
+++ b/src/index.css
@@ -178,3 +178,12 @@
     opacity: 1;
   }
 }
+
+#splash-screen {
+  @apply fixed inset-0 flex items-center justify-center bg-cream;
+  z-index: 50;
+}
+
+#splash-screen img {
+  @apply w-32 h-32;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,12 @@ import App from './App.tsx'
 import './index.css'
 import { ThemeProvider } from 'next-themes'
 
-createRoot(document.getElementById("root")!).render(
+const root = createRoot(document.getElementById('root')!);
+
+root.render(
   <ThemeProvider attribute="class" defaultTheme="light">
     <App />
   </ThemeProvider>
 );
+
+document.getElementById('splash-screen')?.remove();


### PR DESCRIPTION
## Summary
- display a splash screen before the React app loads
- hide the splash screen once React is initialized
- style the splash screen with a cream background and centered logo

## Testing
- `npm run lint` *(fails: Unexpected any, no-case-declarations, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d995abff48324ae1f153fbf9e426d