### PR TITLE
Implement admin role system with Supabase

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ const Header = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [showInstallDialog, setShowInstallDialog] = useState(false);
-  const { user, profile, signOut } = useAuth();
+  const { user, userRole, profile, signOut } = useAuth();
   const { isInstallable, isInstalled, installApp } = usePWAInstall();
   const { toast } = useToast();
 
@@ -82,7 +82,7 @@ const Header = () => {
                 {item.name}
               </a>
             ))}
-            {profile?.role === 'admin' && (
+            {userRole === 'Admin' && (
               <Link
                 to="/admin"
                 className="text-slate-gray dark:text-white hover:text-forest-green transition-colors duration-200 font-medium"
@@ -115,7 +115,10 @@ const Header = () => {
               <div className="flex items-center space-x-3">
                 <div className="flex items-center space-x-2 text-slate-gray dark:text-cream">
                   <User className="w-4 h-4" />
-                  <span className="text-sm">{user.email}</span>
+                  <span className="text-sm">
+                    {user.email}
+                    {userRole && ` (${userRole})`}
+                  </span>
                 </div>
                 <Button
                   onClick={handleSignOut}
@@ -184,7 +187,7 @@ const Header = () => {
                 {item.name}
               </a>
             ))}
-            {profile?.role === 'admin' && (
+            {userRole === 'Admin' && (
               <Link
                 to="/admin"
                 className="text-slate-gray dark:text-white hover:text-forest-green dark:hover:text-white/80 transition-colors duration-200 font-medium px-4 py-2"
@@ -198,7 +201,10 @@ const Header = () => {
                   <div className="space-y-2">
                     <div className="flex items-center space-x-2 text-slate-gray dark:text-white text-sm">
                       <User className="w-4 h-4" />
-                      <span>{user.email}</span>
+                      <span>
+                        {user.email}
+                        {userRole && ` (${userRole})`}
+                      </span>
                     </div>
                     <Button
                       onClick={handleSignOut}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -122,6 +122,24 @@ export type Database = {
         }
         Relationships: []
       }
+      users: {
+        Row: {
+          id: string
+          email: string
+          role: string
+        }
+        Insert: {
+          id: string
+          email: string
+          role?: string
+        }
+        Update: {
+          id?: string
+          email?: string
+          role?: string
+        }
+        Relationships: []
+      }
       push_subscriptions: {
         Row: {
           auth_key: string

--- a/src/pages/AccessDenied.tsx
+++ b/src/pages/AccessDenied.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const AccessDenied = () => (
+  <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="text-center space-y-4">
+      <h1 className="text-3xl font-bold text-forest-green">Access Denied</h1>
+      <p className="text-slate-gray">You do not have permission to view this page.</p>
+      <Link to="/" className="text-forest-green hover:text-forest-green/80 underline">
+        Return Home
+      </Link>
+    </div>
+  </div>
+);
+
+export default AccessDenied;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { useAuth } from '@/hooks/useAuth';
-import NotFound from './NotFound';
+import AccessDenied from './AccessDenied';
 
 const Admin = () => {
-  const { user, profile, loading } = useAuth();
+  const { user, userRole, profile, loading } = useAuth();
 
   if (loading) return null;
 
-  if (!user || profile?.role !== 'admin') {
-    return <NotFound />;
+  if (!user || userRole !== 'Admin') {
+    return <AccessDenied />;
   }
 
   return (
@@ -19,9 +19,13 @@ const Admin = () => {
       <main className="py-16">
         <div className="container mx-auto px-4">
           <h1 className="text-3xl font-bold text-forest-green mb-4">Admin Dashboard</h1>
-          <p className="text-slate-gray">
-            Welcome, {profile?.full_name || user.email}! This page is only visible to administrators.
+          <p className="text-slate-gray mb-6">
+            Welcome, {profile?.full_name || user.email}! You have <span className="font-semibold">{userRole}</span> access.
           </p>
+          <div className="border border-sage/50 p-6 rounded-lg text-slate-gray">
+            <p className="mb-2">Placeholder for admin tools.</p>
+            <p>Manage users or view reports here.</p>
+          </div>
         </div>
       </main>
       <Footer />

--- a/supabase/migrations/20250721020000-create-users-table.sql
+++ b/supabase/migrations/20250721020000-create-users-table.sql
@@ -1,0 +1,34 @@
+-- Create users table for role management
+CREATE TABLE public.users (
+  id UUID NOT NULL PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email TEXT NOT NULL UNIQUE,
+  role TEXT NOT NULL DEFAULT 'Client' CHECK (role IN ('Admin','Client'))
+);
+
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own role" ON public.users
+FOR SELECT USING (auth.uid() = id);
+
+CREATE OR REPLACE FUNCTION public.add_user_role()
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.users (id, email, role)
+  VALUES (NEW.id, NEW.email, 'Client');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_auth_user_created_users ON auth.users;
+CREATE TRIGGER on_auth_user_created_users
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.add_user_role();
+
+-- Backfill existing users
+INSERT INTO public.users (id, email, role)
+SELECT id, email, 'Client'
+FROM auth.users
+ON CONFLICT (id) DO NOTHING;
+
+-- Assign admin role to james@hennahane.com if present
+UPDATE public.users SET role = 'Admin' WHERE email = 'james@hennahane.com';


### PR DESCRIPTION
## Summary
- add SQL migration for a `users` table with roles
- extend Supabase types to include the new table
- fetch user role in `useAuth` and expose `userRole`
- protect `/admin` route with `AccessDenied` fallback and show admin tools placeholder
- show user role in navigation and hide Admin link unless role is `Admin`

## Testing
- `npm run lint` *(fails: 14 errors, 12 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d9db72f18832485783724b392ab76