### PR TITLE
Add animated splash screen

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,8 +5,8 @@
   "description": "Kansas City's trusted AI consultancy for small businesses. Expert guidance on Microsoft AI tools, custom solutions, and sustainable growth strategies.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#065f46",
+  "background_color": "#F8E5C5",
+  "theme_color": "#44623B",
   "orientation": "portrait-primary",
   "scope": "/",
   "icons": [

--- a/src/index.css
+++ b/src/index.css
@@ -179,11 +179,24 @@
   }
 }
 
+@keyframes splashIn {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 #splash-screen {
-  @apply fixed inset-0 flex items-center justify-center bg-cream;
+  @apply fixed inset-0 flex items-center justify-center;
+  background-color: #F8E5C5;
   z-index: 50;
 }
 
 #splash-screen img {
   @apply w-32 h-32;
+  animation: splashIn 1.5s ease-in-out forwards;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,4 +11,8 @@ root.render(
   </ThemeProvider>
 );
 
-document.getElementById('splash-screen')?.remove();
+const splash = document.getElementById('splash-screen');
+if (splash) {
+  // Allow the splash animation to play before removing
+  setTimeout(() => splash.remove(), 1500);
+}


### PR DESCRIPTION
## Summary
- animate the splash screen logo on startup
- keep splash screen visible briefly before removal
- update splash background to the requested color
- update PWA manifest theme and background colors

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687da69e69088324ad0dc8a5c12ca27f