### PR TITLE
Implement RBAC with Supabase

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,11 @@ import { AuthProvider } from "@/hooks/useAuth";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import Admin from "./pages/Admin";
+import AdminCenter from "./pages/AdminCenter";
+import AccessDenied from "./pages/AccessDenied";
 import NotFound from "./pages/NotFound";
 import VapidSetup from "./pages/VapidSetup";
+import PrivateRoute from "./components/PrivateRoute";
 
 const queryClient = new QueryClient();
 
@@ -25,8 +28,31 @@ const App = () => {
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/auth" element={<Auth />} />
-              <Route path="/admin" element={<Admin />} />
-              <Route path="/vapid-setup" element={<VapidSetup />} />
+              <Route
+                path="/admin"
+                element={
+                  <PrivateRoute requiredRoles={["Admin"]}>
+                    <Admin />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/admin-center"
+                element={
+                  <PrivateRoute requiredRoles={["Admin"]}>
+                    <AdminCenter />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/vapid-setup"
+                element={
+                  <PrivateRoute requiredRoles={["Admin", "Client"]}>
+                    <VapidSetup />
+                  </PrivateRoute>
+                }
+              />
+              <Route path="/access-denied" element={<AccessDenied />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { Sprout, LogOut, User, Download } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 import PWAInstallDialog from './PWAInstallDialog';
 import { useAuth } from '@/hooks/useAuth';
+import { usePermissions } from '@/hooks/usePermissions';
 import { usePWAInstall } from '@/hooks/usePWAInstall';
 import { Link } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
@@ -26,7 +27,9 @@ const Header = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const navItems = [
+  const permissions = usePermissions();
+
+  const baseNavItems = [
     { name: 'Home', href: '#home' },
     { name: 'About', href: '#about' },
     { name: 'Services', href: '#services' },
@@ -34,6 +37,12 @@ const Header = () => {
     { name: 'Team', href: '#team' },
     { name: 'Contact', href: '#contact' }
   ];
+
+  const dynamicNav = permissions
+    .filter((p) => p.visible && p.menu_item)
+    .map((p) => ({ name: p.menu_item as string, href: p.page }));
+
+  const navItems = [...baseNavItems, ...dynamicNav];
 
   const handleSignOut = async () => {
     try {
@@ -74,22 +83,24 @@ const Header = () => {
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-8">
             {navItems.map((item) => (
-              <a
-                key={item.name}
-                href={item.href}
-                className="text-slate-gray dark:text-white hover:text-forest-green transition-colors duration-200 font-medium"
-              >
-                {item.name}
-              </a>
+              item.href.startsWith('/') ? (
+                <Link
+                  key={item.name}
+                  to={item.href}
+                  className="text-slate-gray dark:text-white hover:text-forest-green transition-colors duration-200 font-medium"
+                >
+                  {item.name}
+                </Link>
+              ) : (
+                <a
+                  key={item.name}
+                  href={item.href}
+                  className="text-slate-gray dark:text-white hover:text-forest-green transition-colors duration-200 font-medium"
+                >
+                  {item.name}
+                </a>
+              )
             ))}
-            {userRole === 'Admin' && (
-              <Link
-                to="/admin"
-                className="text-slate-gray dark:text-white hover:text-forest-green transition-colors duration-200 font-medium"
-              >
-                Admin
-              </Link>
-            )}
           </nav>
 
           {/* CTA Button / Auth */}
@@ -178,24 +189,26 @@ const Header = () => {
           <div className="md:hidden bg-white dark:bg-slate-900 border-t border-sage/20 dark:border-sage/50 py-4 animate-fade-in">
             <nav className="flex flex-col space-y-4">
             {navItems.map((item) => (
-              <a
-                key={item.name}
-                href={item.href}
-                className="text-slate-gray dark:text-white hover:text-forest-green dark:hover:text-white/80 transition-colors duration-200 font-medium px-4 py-2"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                {item.name}
-              </a>
+              item.href.startsWith('/') ? (
+                <Link
+                  key={item.name}
+                  to={item.href}
+                  className="text-slate-gray dark:text-white hover:text-forest-green dark:hover:text-white/80 transition-colors duration-200 font-medium px-4 py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  {item.name}
+                </Link>
+              ) : (
+                <a
+                  key={item.name}
+                  href={item.href}
+                  className="text-slate-gray dark:text-white hover:text-forest-green dark:hover:text-white/80 transition-colors duration-200 font-medium px-4 py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  {item.name}
+                </a>
+              )
             ))}
-            {userRole === 'Admin' && (
-              <Link
-                to="/admin"
-                className="text-slate-gray dark:text-white hover:text-forest-green dark:hover:text-white/80 transition-colors duration-200 font-medium px-4 py-2"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                Admin
-              </Link>
-            )}
               <div className="px-4 pt-2 space-y-2">
                 {user ? (
                   <div className="space-y-2">

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
+
+interface PrivateRouteProps {
+  children: JSX.Element;
+  requiredRoles: string[];
+}
+
+const PrivateRoute = ({ children, requiredRoles }: PrivateRouteProps) => {
+  const { user, userRole, loading } = useAuth();
+  if (loading) return null;
+  const role = userRole ?? 'public';
+  if (!user || !requiredRoles.includes(role)) {
+    return <Navigate to="/access-denied" replace />;
+  }
+  return children;
+};
+
+export default PrivateRoute;

--- a/src/hooks/usePermissions.tsx
+++ b/src/hooks/usePermissions.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import type { Tables } from '@/integrations/supabase/types';
+import { useAuth } from './useAuth';
+
+export const usePermissions = () => {
+  const { userRole } = useAuth();
+  const [permissions, setPermissions] = useState<Tables<'role_permissions'>[]>([]);
+
+  useEffect(() => {
+    const role = userRole ?? 'public';
+    supabase
+      .from('role_permissions')
+      .select('*')
+      .eq('role', role)
+      .then(({ data, error }) => {
+        if (error) {
+          console.error('Failed to fetch permissions', error);
+        } else {
+          setPermissions(data ?? []);
+        }
+      });
+  }, [userRole]);
+
+  return permissions;
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -206,6 +206,33 @@ export type Database = {
         }
         Relationships: []
       }
+      role_permissions: {
+        Row: {
+          id: string
+          role: string
+          page: string
+          access: boolean
+          menu_item: string | null
+          visible: boolean
+        }
+        Insert: {
+          id?: string
+          role: string
+          page: string
+          access?: boolean
+          menu_item?: string | null
+          visible?: boolean
+        }
+        Update: {
+          id?: string
+          role?: string
+          page?: string
+          access?: boolean
+          menu_item?: string | null
+          visible?: boolean
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/pages/AdminCenter.tsx
+++ b/src/pages/AdminCenter.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import AccessDenied from './AccessDenied';
+import { useAuth } from '@/hooks/useAuth';
+import { supabase } from '@/integrations/supabase/client';
+import type { Tables } from '@/integrations/supabase/types';
+
+const AdminCenter = () => {
+  const { user, userRole } = useAuth();
+  const [perms, setPerms] = useState<Tables<'role_permissions'>[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (userRole === 'Admin') {
+      supabase
+        .from('role_permissions')
+        .select('*')
+        .then(({ data, error }) => {
+          if (!error) setPerms(data ?? []);
+          setLoading(false);
+        });
+    } else {
+      setLoading(false);
+    }
+  }, [userRole]);
+
+  const update = async (
+    id: string,
+    field: 'access' | 'visible',
+    value: boolean
+  ) => {
+    const { data, error } = await supabase
+      .from('role_permissions')
+      .update({ [field]: value })
+      .eq('id', id)
+      .single();
+    if (!error && data) {
+      setPerms((p) => p.map((perm) => (perm.id === id ? data : perm)));
+    } else if (error) {
+      console.error('Failed to update permission', error);
+    }
+  };
+
+  if (loading) return null;
+  if (!user || userRole !== 'Admin') return <AccessDenied />;
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <main className="py-16">
+        <div className="container mx-auto px-4 space-y-6">
+          <h1 className="text-3xl font-bold text-forest-green mb-4">Admin Center</h1>
+          <table className="min-w-full border border-sage divide-y divide-sage">
+            <thead className="bg-sage/20">
+              <tr>
+                <th className="px-3 py-2 text-left">Role</th>
+                <th className="px-3 py-2 text-left">Page</th>
+                <th className="px-3 py-2">Access</th>
+                <th className="px-3 py-2">Menu Item</th>
+                <th className="px-3 py-2">Visible</th>
+              </tr>
+            </thead>
+            <tbody>
+              {perms.map((p) => (
+                <tr key={p.id} className="border-t">
+                  <td className="px-3 py-2">{p.role}</td>
+                  <td className="px-3 py-2">{p.page}</td>
+                  <td className="px-3 py-2 text-center">
+                    <input
+                      type="checkbox"
+                      checked={p.access}
+                      onChange={(e) => update(p.id, 'access', e.target.checked)}
+                    />
+                  </td>
+                  <td className="px-3 py-2">{p.menu_item || '-'}</td>
+                  <td className="px-3 py-2 text-center">
+                    <input
+                      type="checkbox"
+                      checked={p.visible}
+                      onChange={(e) => update(p.id, 'visible', e.target.checked)}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default AdminCenter;

--- a/supabase/migrations/20250801000000-create-role-permissions.sql
+++ b/supabase/migrations/20250801000000-create-role-permissions.sql
@@ -1,0 +1,33 @@
+-- Create role_permissions table for menu and page access
+CREATE TABLE public.role_permissions (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  role text NOT NULL,
+  page text NOT NULL,
+  access boolean NOT NULL DEFAULT false,
+  menu_item text,
+  visible boolean NOT NULL DEFAULT false
+);
+
+ALTER TABLE public.role_permissions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow read role permissions" ON public.role_permissions
+FOR SELECT USING (true);
+
+CREATE POLICY "Admins manage role permissions" ON public.role_permissions
+FOR ALL USING (
+  EXISTS (
+    SELECT 1 FROM public.users u
+    WHERE u.id = auth.uid() AND u.role = 'Admin'
+  )
+);
+
+-- Default permissions
+INSERT INTO public.role_permissions (role, page, access, menu_item, visible) VALUES
+  ('public', '/', true, NULL, false),
+  ('public', '/auth', true, NULL, false),
+  ('client', '/', true, NULL, false),
+  ('client', '/vapid-setup', true, 'VAPID Setup', true),
+  ('admin', '/', true, NULL, false),
+  ('admin', '/admin', true, 'Admin', true),
+  ('admin', '/admin-center', true, 'Admin Center', true),
+  ('admin', '/vapid-setup', true, 'VAPID Setup', true);


### PR DESCRIPTION
## Summary
- add `role_permissions` table and policies
- include permission hook and private route component
- load menu items dynamically based on role
- secure routes `/admin`, `/admin-center` and `/vapid-setup`
- provide admin center UI for managing permissions

## Testing
- `npm run lint` *(fails: Unexpected any & other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687dad9d773883248278606f46647197