### PR TITLE
Move notification debug to admin page

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,6 +1,5 @@
 
 import React from 'react';
-import { NotificationDebugger } from './NotificationDebugger';
 import { Card, CardContent } from '@/components/ui/card';
 
 const About = () => {
@@ -150,11 +149,6 @@ const About = () => {
           </div>
         </div>
         
-        {/* Debug Section - Remove in production */}
-        <div className="mt-16">
-          <h3 className="text-2xl font-bold text-forest-green mb-6 text-center">Push Notification Debug</h3>
-          <NotificationDebugger />
-        </div>
       </div>
     </section>
   );

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import { NotificationDebugger } from '@/components/NotificationDebugger';
 import { useAuth } from '@/hooks/useAuth';
 import AccessDenied from './AccessDenied';
 
@@ -34,6 +35,11 @@ const Admin = () => {
           <div className="border border-sage/50 p-6 rounded-lg text-slate-gray">
             <p className="mb-2">Placeholder for admin tools.</p>
             <p>Manage users or view reports here.</p>
+          </div>
+
+          <div className="mt-12">
+            <h2 className="text-2xl font-bold text-forest-green mb-6 text-center">Push Notification Debug</h2>
+            <NotificationDebugger />
           </div>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- remove Push Notification Debug from About page
- add NotificationDebugger widget to Admin page

## Testing
- `npm run lint` *(fails: Unexpected any, no-case-declarations)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ee11e63188324b30eb144fe432127