### PR TITLE
Fix VAPID key generation and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ npm run build
 npm run preview
 ```
 
+## 🔔 Push Notifications Setup
+
+1. **Generate VAPID Keys**
+   - Run the `generate-vapid-keys` edge function:
+     ```bash
+     supabase functions invoke generate-vapid-keys
+     ```
+   - Copy the returned `publicKey` and `privateKey` values.
+
+2. **Store the Private Key**
+   - In the Supabase dashboard go to **Project Settings → Functions → Secrets**.
+   - Add a secret named `VAPID_PRIVATE_KEY` with the value of your generated private key.
+
+3. **Update the Public Key**
+   - Replace the `VAPID_PUBLIC_KEY` constant in `src/hooks/usePushNotifications.tsx`
+     and `supabase/functions/send-push-notifications/index.ts` with your new public key.
+
+4. **Deploy Functions**
+   - Redeploy your edge functions so they pick up the new secret and public key.
+
 ## 📄 License
 
 © 2024 RootedAI. All rights reserved.

--- a/src/hooks/usePushNotifications.tsx
+++ b/src/hooks/usePushNotifications.tsx
@@ -22,7 +22,8 @@ interface PushNotificationsHook {
   checkSubscriptionStatus: () => Promise<void>;
 }
 
-const VAPID_PUBLIC_KEY = "BBJeaLq3cweiE_oIJB4EuAIv5Ivua5xmh8IZI68nfmohnsbqtQq6l9_ARSQmDHDNrxUiZRK5UiXW74QuGhSpcKqY";
+// Replace this with your generated public key
+const VAPID_PUBLIC_KEY = "BJr_trKVn2aUm9tMQOuTrsn-ixaiu5bwS_lbcSlasXv8dL-abFhcmNKtvl42IXCs_jikCutIl3kj8X2UsvhkrYw";
 
 export function usePushNotifications(): PushNotificationsHook {
   const [isEnabled, setIsEnabled] = useState(false);

--- a/supabase/functions/generate-vapid-keys/index.ts
+++ b/supabase/functions/generate-vapid-keys/index.ts
@@ -42,7 +42,7 @@ serve(async (req) => {
     return new Response(
       JSON.stringify({
         success: true,
-        publicKey: `B${publicKey}`, // Add the B prefix for uncompressed point
+        publicKey,
         privateKey,
         message: "VAPID keys generated successfully. Store these securely!"
       }),

--- a/supabase/functions/send-push-notifications/index.ts
+++ b/supabase/functions/send-push-notifications/index.ts
@@ -20,7 +20,8 @@ interface NotificationPayload {
   data?: any
 }
 
-const VAPID_PUBLIC_KEY = "BBJeaLq3cweiE_oIJB4EuAIv5Ivua5xmh8IZI68nfmohnsbqtQq6l9_ARSQmDHDNrxUiZRK5UiXW74QuGhSpcKqY"
+// Replace this with your generated public key
+const VAPID_PUBLIC_KEY = "BJr_trKVn2aUm9tMQOuTrsn-ixaiu5bwS_lbcSlasXv8dL-abFhcmNKtvl42IXCs_jikCutIl3kj8X2UsvhkrYw"
 
 async function sendWebPush(subscription: PushSubscription, payload: NotificationPayload): Promise<boolean> {
   try {


### PR DESCRIPTION
## Summary
- correct VAPID key generator to stop prefixing an extra `B`
- update public key constants with a properly generated key
- document how to generate keys and store the private key in Supabase

## Testing
- `npm run lint` *(fails: Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_e_687f068cb4d4832483347a9d2ea08ed7