### PR TITLE
Fix Survey Institute link

### DIFF
--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -89,7 +89,7 @@ const Reviews = () => {
             return testimonial.company === "The Survey Institute" ? (
               <a
                 key={index}
-                href="https://fast.com/"
+                href="https://surveyinstitute.com/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block"


### PR DESCRIPTION
## Summary
- fix The Survey Institute review card link so it points to `https://surveyinstitute.com`

## Testing
- `npm run lint` *(fails: no-case-declarations, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688062621b14832499ce6575e852c82e