### PR TITLE
Add mobile zoom and spin gestures for team profiles

### DIFF
--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -6,12 +6,14 @@ import { Globe } from 'lucide-react';
 const ProfileImage = ({ member, index }: { member: any, index: number }) => {
   const [rotation, setRotation] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [isZoomed, setIsZoomed] = useState(false);
   const velocityRef = useRef(0);
   const lastTimeRef = useRef(0);
   const animationRef = useRef<number>();
   const containerRef = useRef<HTMLDivElement>(null);
   const startXRef = useRef(0);
   const startRotationRef = useRef(0);
+  const startTouchRef = useRef({ x: 0, y: 0 });
 
   const logoUrl = "/lovable-uploads/ce6a66fb-80e8-4092-84eb-db436fcb1cad.png";
 
@@ -56,8 +58,10 @@ const ProfileImage = ({ member, index }: { member: any, index: number }) => {
 
   // Touch handlers
   const handleTouchStart = (e: React.TouchEvent) => {
-    startXRef.current = e.touches[0].clientX;
+    const touch = e.touches[0];
+    startXRef.current = touch.clientX;
     startRotationRef.current = rotation;
+    startTouchRef.current = { x: touch.clientX, y: touch.clientY };
     lastTimeRef.current = Date.now();
     if (animationRef.current) {
       cancelAnimationFrame(animationRef.current);
@@ -82,7 +86,22 @@ const ProfileImage = ({ member, index }: { member: any, index: number }) => {
     lastTimeRef.current = currentTime;
   };
 
-  const handleTouchEnd = () => {
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    const touch = e.changedTouches[0];
+    const dx = touch.clientX - startTouchRef.current.x;
+    const dy = touch.clientY - startTouchRef.current.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+
+    if (!isZoomed && distance < 10) {
+      setIsZoomed(true);
+      return;
+    }
+
+    if (isZoomed && distance > 50) {
+      setIsZoomed(false);
+      return;
+    }
+
     setIsAnimating(true);
     animationRef.current = requestAnimationFrame(animate);
   };
@@ -96,15 +115,26 @@ const ProfileImage = ({ member, index }: { member: any, index: number }) => {
   }, []);
 
   return (
-    <div className="relative w-24 h-24">
+    <div
+      className={`${
+        isZoomed
+          ? 'fixed inset-0 z-50 flex items-center justify-center bg-black/80'
+          : 'relative w-24 h-24'
+      } transition-all duration-300`}
+    >
       <div
         ref={containerRef}
-        className="w-24 h-24 preserve-3d cursor-pointer"
+        className={`preserve-3d cursor-pointer transition-all duration-300 ${
+          isZoomed ? 'w-full h-full' : 'w-24 h-24'
+        }`}
         onMouseEnter={handleMouseEnter}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
-        style={{ 
+        onClick={() => {
+          if (!isZoomed) setIsZoomed(true);
+        }}
+        style={{
           perspective: '1000px',
           touchAction: 'none',
           userSelect: 'none',
@@ -114,25 +144,35 @@ const ProfileImage = ({ member, index }: { member: any, index: number }) => {
       >
         {/* Profile Image */}
         <div
-          className="absolute inset-0 w-24 h-24 backface-hidden"
+          className={`absolute inset-0 backface-hidden ${
+            isZoomed ? 'w-full h-full' : 'w-24 h-24'
+          }`}
           style={{ backfaceVisibility: 'hidden' }}
         >
           <img
             src={member.image}
             alt={member.name}
-            className="w-24 h-24 rounded-full object-cover border-4 border-sage/30"
+            className={`${
+              isZoomed ? 'w-full h-full' : 'w-24 h-24'
+            } rounded-full object-cover border-4 border-sage/30`}
           />
         </div>
         
         {/* Logo Back */}
         <div
-          className="absolute inset-0 w-24 h-24 backface-hidden"
-          style={{ 
+          className={`absolute inset-0 backface-hidden ${
+            isZoomed ? 'w-full h-full' : 'w-24 h-24'
+          }`}
+          style={{
             backfaceVisibility: 'hidden',
             transform: 'rotateY(180deg)'
           }}
         >
-          <div className="w-24 h-24 rounded-full bg-white border-4 border-sage/30 flex items-center justify-center p-1">
+          <div
+            className={`${
+              isZoomed ? 'w-full h-full' : 'w-24 h-24'
+            } rounded-full bg-white border-4 border-sage/30 flex items-center justify-center p-1`}
+          >
             <img
               src={logoUrl}
               alt="RootedAI Logo"
@@ -141,9 +181,11 @@ const ProfileImage = ({ member, index }: { member: any, index: number }) => {
           </div>
         </div>
       </div>
-      
+
       {/* Background overlay to maintain original styling */}
-      <div className="absolute inset-0 w-24 h-24 rounded-full bg-forest-green/10 pointer-events-none"></div>
+      {!isZoomed && (
+        <div className="absolute inset-0 w-24 h-24 rounded-full bg-forest-green/10 pointer-events-none"></div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enable a fullscreen zoom view for team profile photos
- allow swipe gestures to dismiss the zoomed photo
- support swipe-based spinning with momentum

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688835c3bd688324b251c87f0dffe3c2