### PR TITLE
Improve mobile responsiveness for invite tables

### DIFF
--- a/src/components/InvitationsTable.tsx
+++ b/src/components/InvitationsTable.tsx
@@ -131,7 +131,7 @@ const InvitationsTable = () => {
           <p className="text-slate-gray text-center py-8">No invitations sent yet.</p>
         ) : (
           <div className="overflow-x-auto">
-            <table className="w-full border border-sage/50 divide-y divide-sage/50">
+            <table className="min-w-[40rem] w-full border border-sage/50 divide-y divide-sage/50">
               <thead className="bg-sage/20">
                 <tr>
                   <th className="px-4 py-3 text-left text-sm font-medium text-forest-green">Name</th>

--- a/src/components/InviteUserForm.tsx
+++ b/src/components/InviteUserForm.tsx
@@ -86,7 +86,8 @@ const InviteUserForm = ({ onInvitationSent }: InviteUserFormProps) => {
         </p>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="overflow-x-auto">
+          <form onSubmit={handleSubmit} className="space-y-4 min-w-[20rem]">
           <div className="space-y-2">
             <Label htmlFor="email" className="flex items-center gap-2">
               <Mail className="h-4 w-4" />
@@ -140,14 +141,15 @@ const InviteUserForm = ({ onInvitationSent }: InviteUserFormProps) => {
             </Select>
           </div>
 
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
             disabled={isLoading}
             className="w-full bg-forest-green hover:bg-forest-green/90"
           >
             {isLoading ? "Sending..." : "Send Invitation"}
           </Button>
         </form>
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- make `InviteUserForm` scrollable on small screens
- set a minimum width for `InvitationsTable` so mobile users can scroll horizontally

## Testing
- `npm run lint` *(fails: cannot pass existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888426ecd7c8324a90cb9b8953599a2