### PR TITLE
Update header nav to remove Home and link logo

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,7 +30,6 @@ const Header = () => {
   const { menuPermissions } = useRolePermissions();
 
   const baseNavItems = [
-    { name: 'Home', href: '#home' },
     { name: 'About', href: '#about' },
     { name: 'Services', href: '#services' },
     { name: 'Reviews', href: '#reviews' },
@@ -71,14 +70,14 @@ const Header = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16 lg:h-20">
           {/* Logo */}
-          <div className="flex items-center space-x-2">
-            <img 
+          <a href="#home" className="flex items-center space-x-2">
+            <img
               src="/lovable-uploads/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
-              alt="RootedAI Logo" 
-              className="w-8 h-8" 
+              alt="RootedAI Logo"
+              className="w-8 h-8"
             />
             <span className="text-xl lg:text-2xl font-bold text-forest-green">RootedAI</span>
-          </div>
+          </a>
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- remove `Home` entry from the header nav
- make the RootedAI logo/text scroll to the `home` section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688982deb14483248c20db152f36c18a