### PR TITLE
Fix email text color in dark mode

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -124,7 +124,7 @@ const Header = () => {
             {/* Auth buttons */}
             {user ? (
               <div className="flex items-center space-x-3">
-                <div className="flex items-center space-x-2 text-slate-gray dark:text-cream">
+                <div className="flex items-center space-x-2 text-slate-gray dark:text-white">
                   <User className="w-4 h-4" />
                   <span className="text-sm">
                     {user.email}


### PR DESCRIPTION
## Summary
- ensure user email text is white in dark mode

## Testing
- `npm run lint` *(fails: no-useless-escape, @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_688982ff93c88324b9841fc102384acf