### PR TITLE
Fix admin user table

### DIFF
--- a/src/components/UserRoleManager.tsx
+++ b/src/components/UserRoleManager.tsx
@@ -40,9 +40,9 @@ const UserRoleManager = ({ onUserUpdated }: UserRoleManagerProps) => {
       // Validate input data
       const validatedData = userRoleUpdateSchema.parse({ email, role });
 
-      // Check if user exists first
+      // Check if user profile exists first
       const { data: existingUser, error: checkError } = await supabase
-        .from('users')
+        .from('profiles')
         .select('id, role')
         .eq('email', validatedData.email)
         .maybeSingle();
@@ -52,26 +52,15 @@ const UserRoleManager = ({ onUserUpdated }: UserRoleManagerProps) => {
       }
 
       if (!existingUser) {
-        // Create new user
-        const { error: insertError } = await supabase
-          .from('users')
-          .insert({
-            email: validatedData.email,
-            role: validatedData.role
-          });
-
-        if (insertError) {
-          throw new Error(`Failed to create user: ${insertError.message}`);
-        }
-
         toast({
-          title: "User Created",
-          description: `User ${validatedData.email} created with role ${validatedData.role}`,
+          title: "User Not Found",
+          description: `No profile found for ${validatedData.email}`,
+          variant: "destructive"
         });
       } else {
         // Update existing user
         const { error: updateError } = await supabase
-          .from('users')
+          .from('profiles')
           .update({ role: validatedData.role })
           .eq('email', validatedData.email);
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -35,29 +35,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
-  const fetchUserRole = async (email: string) => {
+  const fetchUserRole = async (userId: string) => {
     try {
       const { data, error } = await supabase
-        .from('users')
+        .from('profiles')
         .select('role')
-        .eq('email', email)
+        .eq('user_id', userId)
         .maybeSingle();
-      
+
       if (!error && data) {
         setUserRole(data.role);
-      } else if (!error && !data) {
-        // Create user with Public role by default
-        const { data: newUser, error: insertError } = await supabase
-          .from('users')
-          .insert({ email, role: 'Public' })
-          .select('role')
-          .single();
-        
-        if (!insertError && newUser) {
-          setUserRole(newUser.role);
-        }
-      } else {
-        console.error('Error fetching user role:', error);
       }
     } catch (error) {
       console.error('Error in fetchUserRole:', error);
@@ -70,9 +57,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       (event, session) => {
         setSession(session);
         setUser(session?.user ?? null);
-        if (session?.user?.email) {
+        if (session?.user) {
           fetchProfile(session.user.id);
-          setTimeout(() => fetchUserRole(session.user.email!), 0);
+          setTimeout(() => fetchUserRole(session.user.id), 0);
         } else {
           setProfile(null);
           setUserRole(null);
@@ -85,9 +72,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
       setUser(session?.user ?? null);
-      if (session?.user?.email) {
+      if (session?.user) {
         fetchProfile(session.user.id);
-        setTimeout(() => fetchUserRole(session.user.email!), 0);
+        setTimeout(() => fetchUserRole(session.user.id), 0);
       }
       setLoading(false);
     });

--- a/src/hooks/useUserRole.tsx
+++ b/src/hooks/useUserRole.tsx
@@ -9,9 +9,9 @@ export const useUserRole = () => {
     const ensureUserRole = async () => {
       if (!user?.email) return;
 
-      // Check if user exists in users table
+      // Check if user profile exists
       const { data: existingUser, error } = await supabase
-        .from('users')
+        .from('profiles')
         .select('role')
         .eq('email', user.email)
         .maybeSingle();
@@ -21,18 +21,7 @@ export const useUserRole = () => {
         return;
       }
 
-      if (!existingUser) {
-        // Create user with Public role by default
-        const { data: newUser, error: insertError } = await supabase
-          .from('users')
-          .insert({ email: user.email, role: 'Public' })
-          .select('role')
-          .single();
-
-        if (!insertError && newUser) {
-          setUserRole(newUser.role);
-        }
-      } else if (!userRole) {
+      if (existingUser && !userRole) {
         setUserRole(existingUser.role);
       }
     };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -74,6 +74,7 @@ export type Database = {
           email: string
           full_name: string | null
           id: string
+          role: string
           updated_at: string
           user_id: string
         }
@@ -82,6 +83,7 @@ export type Database = {
           email: string
           full_name?: string | null
           id?: string
+          role?: string
           updated_at?: string
           user_id: string
         }
@@ -90,6 +92,7 @@ export type Database = {
           email?: string
           full_name?: string | null
           id?: string
+          role?: string
           updated_at?: string
           user_id?: string
         }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -184,12 +184,9 @@ const Auth = () => {
 
               // Set the user role immediately
               await supabase
-                .from('users')
-                .upsert({ 
-                  id: data.user.id,
-                  email: data.user.email!,
-                  role: invitation.role 
-                }, { onConflict: 'id' });
+                .from('profiles')
+                .update({ role: invitation.role })
+                .eq('user_id', data.user.id);
 
               toast({
                 title: "Welcome to the team!",

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -17,7 +17,7 @@ import InvitationsTable from '@/components/InvitationsTable';
 const UserManagement = () => {
   const { user, userRole, profile, loading } = useAuth();
   const { toast } = useToast();
-  const [users, setUsers] = useState<Tables<'users'>[]>([]);
+  const [users, setUsers] = useState<Tables<'profiles'>[]>([]);
   const [perms, setPerms] = useState<Tables<'role_permissions'>[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(true);
 
@@ -32,11 +32,8 @@ const UserManagement = () => {
 
   const fetchUsers = async () => {
     const { data, error } = await supabase
-      .from('users')
-      .select(`
-        *,
-        profiles!left(full_name)
-      `)
+      .from('profiles')
+      .select('*')
       .order('created_at', { ascending: false });
     
     if (!error) {
@@ -58,9 +55,9 @@ const UserManagement = () => {
 
   const updateUserRole = async (userId: string, newRole: string) => {
     const { error } = await supabase
-      .from('users')
+      .from('profiles')
       .update({ role: newRole })
-      .eq('id', userId);
+      .eq('user_id', userId);
     
     if (!error) {
       setUsers(users.map(u => u.id === userId ? { ...u, role: newRole } : u));
@@ -163,13 +160,13 @@ const UserManagement = () => {
                     {users.map((u: any) => (
                       <tr key={u.id} className="hover:bg-sage/10">
                         <td className="px-4 py-3 text-slate-gray font-medium">
-                          {u.profiles?.full_name || 'N/A'}
+                          {u.full_name || 'N/A'}
                         </td>
                         <td className="px-4 py-3 text-slate-gray">{u.email}</td>
                         <td className="px-4 py-3">
                           <Select
                             value={u.role}
-                            onValueChange={(newRole) => updateUserRole(u.id, newRole)}
+                            onValueChange={(newRole) => updateUserRole(u.user_id, newRole)}
                           >
                             <SelectTrigger className="w-24">
                               <SelectValue />


### PR DESCRIPTION
## Summary
- unify to use `profiles` table for users and roles
- show profiles in Current Users table
- adjust role management utilities

## Testing
- `npm run lint` *(fails: cannot pass due to project lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889823446d48324bb000e361d0ee043