### PR TITLE
Fix admin role check

### DIFF
--- a/src/components/UserRoleManager.tsx
+++ b/src/components/UserRoleManager.tsx
@@ -40,9 +40,9 @@ const UserRoleManager = ({ onUserUpdated }: UserRoleManagerProps) => {
       // Validate input data
       const validatedData = userRoleUpdateSchema.parse({ email, role });
 
-      // Check if user profile exists first
+      // Check if user exists first
       const { data: existingUser, error: checkError } = await supabase
-        .from('profiles')
+        .from('users')
         .select('id, role')
         .eq('email', validatedData.email)
         .maybeSingle();
@@ -60,6 +60,12 @@ const UserRoleManager = ({ onUserUpdated }: UserRoleManagerProps) => {
       } else {
         // Update existing user
         const { error: updateError } = await supabase
+          .from('users')
+          .update({ role: validatedData.role })
+          .eq('email', validatedData.email);
+
+        // Keep profile table in sync if needed
+        await supabase
           .from('profiles')
           .update({ role: validatedData.role })
           .eq('email', validatedData.email);

--- a/src/hooks/useAuthFix.tsx
+++ b/src/hooks/useAuthFix.tsx
@@ -31,8 +31,13 @@ export const useAuthFix = () => {
               user_id: user.id,
               full_name: user.email,
               email: user.email,
-              role: 'client'
+              role: 'Client'
             });
+
+          // Ensure a matching entry exists in the users table
+          await supabase
+            .from('users')
+            .upsert({ id: user.id, email: user.email, role: 'Client' }, { onConflict: 'email' });
 
           if (insertError) {
             console.error('Error creating profile:', insertError);

--- a/src/hooks/useUserRole.tsx
+++ b/src/hooks/useUserRole.tsx
@@ -9,9 +9,9 @@ export const useUserRole = () => {
     const ensureUserRole = async () => {
       if (!user?.email) return;
 
-      // Check if user profile exists
+      // Check the users table first for the current role
       const { data: existingUser, error } = await supabase
-        .from('profiles')
+        .from('users')
         .select('role')
         .eq('email', user.email)
         .maybeSingle();
@@ -23,6 +23,19 @@ export const useUserRole = () => {
 
       if (existingUser && !userRole) {
         setUserRole(existingUser.role);
+        return;
+      }
+
+      const { data: profileData } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('email', user.email)
+        .maybeSingle();
+
+      if (profileData && !userRole) {
+        const normalised =
+          profileData.role.charAt(0).toUpperCase() + profileData.role.slice(1).toLowerCase();
+        setUserRole(normalised);
       }
     };
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -184,6 +184,12 @@ const Auth = () => {
 
               // Set the user role immediately
               await supabase
+                .from('users')
+                .update({ role: invitation.role })
+                .eq('email', invitation.email);
+
+              // Keep the profile table in sync if it has a role column
+              await supabase
                 .from('profiles')
                 .update({ role: invitation.role })
                 .eq('user_id', data.user.id);

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -55,6 +55,12 @@ const UserManagement = () => {
 
   const updateUserRole = async (userId: string, newRole: string) => {
     const { error } = await supabase
+      .from('users')
+      .update({ role: newRole })
+      .eq('id', userId);
+
+    // Keep profiles in sync if they store a role
+    await supabase
       .from('profiles')
       .update({ role: newRole })
       .eq('user_id', userId);


### PR DESCRIPTION
## Summary
- fetch role from `users` table to avoid profile/user mismatch
- keep profile roles in sync when updating users
- sync user role during invitation flow and auth fix hook
- allow admin user management to update the `users` table

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688985ba2b8483249b4598f31e575e47