### PR TITLE
Fix contact form spacing and textarea size

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -59,11 +59,11 @@ const Contact = () => {
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
           {/* Contact Form */}
-          <Card className="border-sage/30 shadow-lg">
+          <Card className="border-sage/30 shadow-lg h-full flex flex-col">
             <CardHeader>
               <CardTitle className="text-2xl text-forest-green">Send us a message</CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="flex-grow flex flex-col">
               <ContactForm />
             </CardContent>
           </Card>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -126,7 +126,7 @@ const ContactForm = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={handleSubmit} className="space-y-6 flex flex-col h-full">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
@@ -185,8 +185,8 @@ const ContactForm = () => {
           value={formData.message}
           onChange={(e) => handleInputChange('message', e.target.value)}
           required
-          rows={6}
-          className="w-full"
+          rows={8}
+          className="w-full min-h-[150px] resize-y"
           placeholder="Tell us about your project or how we can help..."
           maxLength={5000}
         />
@@ -195,10 +195,10 @@ const ContactForm = () => {
         </div>
       </div>
       
-      <Button 
-        type="submit" 
+      <Button
+        type="submit"
         disabled={isSubmitting}
-        className="w-full bg-forest-green hover:bg-forest-green/90"
+        className="w-full bg-forest-green hover:bg-forest-green/90 mt-auto"
       >
         {isSubmitting ? 'Sending...' : 'Send Message'}
       </Button>


### PR DESCRIPTION
## Summary
- align the Send Message button with the Subscribe button by making the contact card fill available height
- allow the message textarea to be larger and resizable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688986e4f23c8324a3f8625e43d37598