### PR TITLE
Simplify admin management

### DIFF
--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
-import { supabase } from '@/integrations/supabase/client';
 
 interface PrivateRouteProps {
   children: JSX.Element;
@@ -10,35 +9,11 @@ interface PrivateRouteProps {
 
 const PrivateRoute = ({ children, requiredRoles }: PrivateRouteProps) => {
   const { user, userRole, loading } = useAuth();
-  const [hasAccess, setHasAccess] = useState<boolean | null>(null);
-  const currentPath = window.location.pathname;
+  if (loading) return null;
 
-  useEffect(() => {
-    const checkAccess = async () => {
-      if (loading || !userRole) return;
-
-      // Check if user has access to this specific page
-      const { data } = await supabase
-        .from('role_permissions')
-        .select('access')
-        .eq('role', userRole)
-        .eq('page', currentPath)
-        .eq('access', true)
-        .maybeSingle();
-
-      // Also check by required roles (fallback)
-      const roleAccess = requiredRoles.includes(userRole);
-      
-      setHasAccess(!!data || roleAccess);
-    };
-
-    checkAccess();
-  }, [user, userRole, loading, currentPath, requiredRoles]);
-
-  if (loading || hasAccess === null) return null;
-  
   const role = userRole ?? 'Public';
-  if (!user || (!hasAccess && !requiredRoles.includes(role))) {
+  const hasAccess = requiredRoles.includes(role);
+  if (!user || !hasAccess) {
     return <Navigate to="/access-denied" replace />;
   }
   

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -45,24 +45,29 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         .eq('email', userEmail)
         .maybeSingle();
 
-      if (!error && data) {
+      if (!error && data?.role) {
         setUserRole(data.role);
         return;
       }
 
-      const { data: profileData } = await supabase
+      const { data: profileData, error: profileError } = await supabase
         .from('profiles')
         .select('role')
         .eq('email', userEmail)
         .maybeSingle();
 
-      if (profileData) {
+      if (!profileError && profileData?.role) {
         const normalised =
           profileData.role.charAt(0).toUpperCase() + profileData.role.slice(1).toLowerCase();
         setUserRole(normalised);
+        return;
       }
+
+      // Fallback so PrivateRoute can resolve even if role lookups fail
+      setUserRole('Public');
     } catch (error) {
       console.error('Error in fetchUserRole:', error);
+      setUserRole('Public');
     }
   };
 

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -9,22 +9,16 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/hooks/use-toast';
-import UserRoleManager from '@/components/UserRoleManager';
-import SecurityAuditDisplay from '@/components/SecurityAuditDisplay';
-import InviteUserForm from '@/components/InviteUserForm';
-import InvitationsTable from '@/components/InvitationsTable';
 
 const UserManagement = () => {
   const { user, userRole, profile, loading } = useAuth();
   const { toast } = useToast();
   const [users, setUsers] = useState<Tables<'profiles'>[]>([]);
-  const [perms, setPerms] = useState<Tables<'role_permissions'>[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(true);
 
   useEffect(() => {
     if (userRole === 'Admin') {
       fetchUsers();
-      fetchPermissions();
     } else {
       setLoadingUsers(false);
     }
@@ -42,16 +36,6 @@ const UserManagement = () => {
     setLoadingUsers(false);
   };
 
-  const fetchPermissions = async () => {
-    const { data, error } = await supabase
-      .from('role_permissions')
-      .select('*')
-      .order('role', { ascending: true });
-    
-    if (!error) {
-      setPerms(data ?? []);
-    }
-  };
 
   const updateUserRole = async (userId: string, newRole: string) => {
     const { error } = await supabase
@@ -81,31 +65,6 @@ const UserManagement = () => {
   };
 
 
-  const updatePermission = async (
-    id: string,
-    field: 'access' | 'visible',
-    value: boolean
-  ) => {
-    const { error } = await supabase
-      .from('role_permissions')
-      .update({ [field]: value })
-      .eq('id', id);
-    
-    if (!error) {
-      setPerms(perms.map(perm => perm.id === id ? { ...perm, [field]: value } : perm));
-      toast({
-        title: "Success",
-        description: "Permission updated successfully",
-      });
-    } else {
-      toast({
-        title: "Error",
-        description: "Failed to update permission",
-        variant: "destructive",
-      });
-    }
-  };
-
   if (loading || loadingUsers) {
     return (
       <div className="min-h-screen bg-cream flex items-center justify-center">
@@ -133,18 +92,6 @@ const UserManagement = () => {
             </p>
           </div>
 
-          {/* Security Audit */}
-          <SecurityAuditDisplay />
-
-          {/* User Invitation System */}
-          <div className="grid md:grid-cols-2 gap-8">
-            <InviteUserForm onInvitationSent={fetchUsers} />
-            <InvitationsTable />
-          </div>
-
-          {/* User Management */}
-          <UserRoleManager onUserUpdated={fetchUsers} />
-
           {/* Current Users Table */}
           <Card>
             <CardHeader>
@@ -163,7 +110,7 @@ const UserManagement = () => {
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-sage/30">
-                    {users.map((u: any) => (
+                    {users.map((u: Tables<'profiles'>) => (
                       <tr key={u.id} className="hover:bg-sage/10">
                         <td className="px-4 py-3 text-slate-gray font-medium">
                           {u.full_name || 'N/A'}
@@ -211,92 +158,6 @@ const UserManagement = () => {
             </CardContent>
           </Card>
 
-          {/* Role-Based Menu & Page Access Control */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-forest-green">Role-Based Access Control</CardTitle>
-              <p className="text-slate-gray text-sm">
-                Configure what each role can access and see in the application menu. Only active pages with valid routes are shown.
-              </p>
-            </CardHeader>
-            <CardContent>
-              <div className="overflow-x-auto">
-                <table className="w-full border border-sage/50 divide-y divide-sage/50">
-                  <thead className="bg-sage/20">
-                    <tr>
-                      <th className="px-3 py-2 text-left text-sm font-medium text-forest-green">Page</th>
-                      <th className="px-3 py-2 text-center text-sm font-medium text-forest-green">Public Access</th>
-                      <th className="px-3 py-2 text-center text-sm font-medium text-forest-green">Client Access</th>
-                      <th className="px-3 py-2 text-center text-sm font-medium text-forest-green">Admin Access</th>
-                      <th className="px-3 py-2 text-center text-sm font-medium text-forest-green">Public Menu</th>
-                      <th className="px-3 py-2 text-center text-sm font-medium text-forest-green">Client Menu</th>
-                      <th className="px-3 py-2 text-center text-sm font-medium text-forest-green">Admin Menu</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-sage/30">
-                    {(() => {
-                      // Group permissions by page
-                      const activePages = ['/', '/admin', '/auth'];
-                      const filteredPerms = perms.filter(p => activePages.includes(p.page));
-                      const pageGroups = filteredPerms.reduce((acc, perm) => {
-                        if (!acc[perm.page]) {
-                          acc[perm.page] = {};
-                        }
-                        acc[perm.page][perm.role] = perm;
-                        return acc;
-                      }, {} as Record<string, Record<string, typeof perms[0]>>);
-                      
-                      const roles = ['Public', 'Client', 'Admin'];
-                      
-                      return Object.entries(pageGroups).map(([page, rolePerms]) => (
-                        <tr key={page} className="hover:bg-sage/10">
-                          <td className="px-3 py-2 text-slate-gray font-medium">
-                            <div className="flex flex-col">
-                              <code className="bg-sage/20 px-2 py-1 rounded text-xs">{page}</code>
-                              {rolePerms[roles[0]]?.menu_item && (
-                                <span className="text-xs text-slate-gray/70 mt-1">
-                                  Menu: {rolePerms[roles[0]].menu_item}
-                                </span>
-                              )}
-                            </div>
-                          </td>
-                          {roles.map(role => (
-                            <td key={`${page}-${role}-access`} className="px-3 py-2 text-center">
-                              <input
-                                type="checkbox"
-                                checked={rolePerms[role]?.access || false}
-                                onChange={(e) => {
-                                  if (rolePerms[role]) {
-                                    updatePermission(rolePerms[role].id, 'access', e.target.checked);
-                                  }
-                                }}
-                                className="w-4 h-4 text-forest-green bg-white border-sage rounded focus:ring-forest-green"
-                              />
-                            </td>
-                          ))}
-                          {roles.map(role => (
-                            <td key={`${page}-${role}-menu`} className="px-3 py-2 text-center">
-                              <input
-                                type="checkbox"
-                                checked={rolePerms[role]?.visible || false}
-                                onChange={(e) => {
-                                  if (rolePerms[role]) {
-                                    updatePermission(rolePerms[role].id, 'visible', e.target.checked);
-                                  }
-                                }}
-                                className="w-4 h-4 text-forest-green bg-white border-sage rounded focus:ring-forest-green"
-                                disabled={!rolePerms[role]?.menu_item}
-                              />
-                            </td>
-                          ))}
-                        </tr>
-                      ));
-                    })()}
-                  </tbody>
-                </table>
-              </div>
-            </CardContent>
-          </Card>
 
         </div>
       </main>


### PR DESCRIPTION
## Summary
- simplify `PrivateRoute` to check only user role
- default user role to `Public` on fetch failure
- trim `/admin` page to basic user role management

## Testing
- `npm run lint` *(fails: 28 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68898a10a32c8324a24974668f96d9d5