### PR TITLE
Remove workshop link from header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -149,9 +149,6 @@ const Header = () => {
                     Sign In
                   </Button>
                 </Link>
-                <Button className="bg-forest-green dark:bg-[hsl(139_28%_25%)] hover:bg-forest-green/90 dark:hover:bg-[hsl(139_28%_20%)] text-white px-6 py-2 rounded-lg transition-all duration-200 hover:shadow-lg">
-                  Book a Workshop
-                </Button>
               </div>
             )}
           </div>
@@ -236,9 +233,6 @@ const Header = () => {
                         Sign In
                       </Button>
                     </Link>
-                    <Button className="w-full bg-forest-green dark:bg-[hsl(139_28%_25%)] hover:bg-forest-green/90 dark:hover:bg-[hsl(139_28%_20%)] text-white py-2 rounded-lg">
-                      Book a Workshop
-                    </Button>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- Remove the "Book a Workshop" button from the header, leaving only the sign-in option for unauthenticated users in both desktop and mobile views.

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: 25 errors, 14 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bfe652cdc8324826025058e97d0b4