### PR TITLE
feat: add expandable service card details

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { ChevronDown } from 'lucide-react';
 
 const Services = () => {
   const services = [
@@ -71,7 +72,10 @@ const Services = () => {
         {/* Services Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
           {services.map((service, index) => (
-            <Card key={index} className="border-sage/30 hover:border-forest-green/50 transition-all duration-300 hover:shadow-lg group">
+            <Card
+              key={index}
+              className="service-card border-sage/30 hover:border-forest-green/50 transition-all duration-300 hover:shadow-lg group"
+            >
               <CardHeader>
                 <div className="flex items-center space-x-4 mb-4">
                   <div className="text-4xl">{service.icon}</div>
@@ -86,7 +90,7 @@ const Services = () => {
                 </div>
               </CardHeader>
               <CardContent>
-                <ul className="space-y-2 mb-6">
+                <ul className="space-y-2 mb-6" data-feature-list>
                   {service.features.map((feature, featureIndex) => (
                     <li key={featureIndex} className="flex items-center space-x-2 text-slate-gray">
                       <div className="w-2 h-2 bg-sage rounded-full"></div>
@@ -96,8 +100,13 @@ const Services = () => {
                 </ul>
                 <div className="flex items-center justify-between">
                   <span className="text-lg font-semibold text-earth-brown">{service.pricing}</span>
-                  <Button variant="outline" className="border-forest-green text-forest-green hover:bg-forest-green dark:hover:bg-[hsl(139_28%_25%)] hover:text-white transition-all duration-200">
-                    Learn More
+                  <Button
+                    variant="outline"
+                    data-learn-more
+                    className="border-forest-green text-forest-green hover:bg-forest-green dark:hover:bg-[hsl(139_28%_25%)] hover:text-white transition-all duration-200"
+                  >
+                    <span className="label">Learn More</span>
+                    <ChevronDown className="ml-2 h-4 w-4 transition-transform duration-300" aria-hidden="true" />
                   </Button>
                 </div>
               </CardContent>

--- a/src/components/scripts/services-learn-more.ts
+++ b/src/components/scripts/services-learn-more.ts
@@ -1,0 +1,119 @@
+const initServicesLearnMore = () => {
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const cards = document.querySelectorAll<HTMLElement>('.service-card');
+
+  cards.forEach((card, index) => {
+    const button = card.querySelector<HTMLButtonElement>('[data-learn-more]');
+    const featureList = card.querySelector<HTMLUListElement>('[data-feature-list]');
+    if (!button || !featureList) return;
+
+    const serviceName = card.querySelector('h3')?.textContent?.trim() || 'Service';
+    const detailsId = `service-details-${index}`;
+
+    let details = card.querySelector<HTMLDivElement>('[data-service-details]');
+    if (!details) {
+      details = document.createElement('div');
+      details.setAttribute('data-service-details', '');
+      details.id = detailsId;
+      details.setAttribute('role', 'region');
+      details.setAttribute('aria-label', `${serviceName} details`);
+      details.className = 'service-details overflow-hidden transition-[height] duration-300 ease-in-out mt-4 motion-reduce:transition-none';
+      details.hidden = true;
+      featureList.insertAdjacentElement('afterend', details);
+    }
+
+    const items = Array.from(featureList.querySelectorAll<HTMLLIElement>('li'));
+    items.forEach((li) => {
+      const title = li.querySelector('span')?.textContent?.trim();
+      if (!title) return;
+
+      let desc = li.getAttribute('data-detail')?.trim();
+      if (!desc) {
+        const span = li.querySelector<HTMLSpanElement>('span.detail');
+        if (span) desc = span.textContent?.trim() || undefined;
+      }
+
+      const item = document.createElement('div');
+      item.className = 'service-detail-item py-2';
+
+      const titleEl = document.createElement('div');
+      titleEl.className = 'service-detail-title text-forest-green font-medium';
+      titleEl.textContent = title;
+      item.appendChild(titleEl);
+
+      if (desc) {
+        const descEl = document.createElement('div');
+        descEl.className = 'service-detail-desc text-slate-gray text-sm mt-1';
+        descEl.textContent = desc;
+        item.appendChild(descEl);
+      }
+
+      details?.appendChild(item);
+    });
+
+    featureList.hidden = true;
+
+    const label = button.querySelector<HTMLElement>('.label');
+    const chevron = button.querySelector<HTMLElement>('svg');
+
+    button.setAttribute('aria-expanded', 'false');
+    button.setAttribute('aria-controls', detailsId);
+
+    const openDetails = () => {
+      if (!details) return;
+      details.hidden = false;
+      const height = details.scrollHeight;
+      details.style.height = '0px';
+      requestAnimationFrame(() => {
+        details!.style.height = `${height}px`;
+      });
+      const onEnd = () => {
+        details!.style.height = '';
+        details!.removeEventListener('transitionend', onEnd);
+      };
+      details.addEventListener('transitionend', onEnd);
+    };
+
+    const closeDetails = () => {
+      if (!details) return;
+      const height = details.scrollHeight;
+      details.style.height = `${height}px`;
+      requestAnimationFrame(() => {
+        details!.style.height = '0px';
+      });
+      const onEnd = () => {
+        details!.hidden = true;
+        details!.style.height = '';
+        details!.removeEventListener('transitionend', onEnd);
+      };
+      details.addEventListener('transitionend', onEnd);
+    };
+
+    button.addEventListener('click', () => {
+      const expanded = button.getAttribute('aria-expanded') === 'true';
+      const next = !expanded;
+      button.setAttribute('aria-expanded', String(next));
+      if (label) label.textContent = next ? 'Show Less' : 'Learn More';
+      if (chevron) chevron.classList.toggle('rotate-180', next);
+
+      if (prefersReducedMotion) {
+        details!.hidden = !next;
+        return;
+      }
+
+      if (next) {
+        openDetails();
+      } else {
+        closeDetails();
+      }
+    });
+  });
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initServicesLearnMore);
+} else {
+  initServicesLearnMore();
+}
+
+export {};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import App from './App.tsx'
 import './index.css'
 import { ThemeProvider } from 'next-themes'
 import './utils/securityEnhancer'
+import './components/scripts/services-learn-more'
 
 const root = createRoot(document.getElementById('root')!);
 


### PR DESCRIPTION
## Summary
- add `service-card` markup with Learn More toggle and chevron
- build `services-learn-more` script to clone bullet list into animated detail panel
- import new script in main entry for DOMContentLoaded setup

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c203745988324947811d88cc24e10