### PR TITLE
Link hero CTA buttons to contact anchor

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -29,11 +29,18 @@ const Hero = () => {
 
           {/* CTA Buttons */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center animate-fade-in-up" style={{animationDelay: '0.4s'}}>
-            <Button className="bg-forest-green dark:bg-[hsl(139_28%_25%)] hover:bg-forest-green/90 dark:hover:bg-[hsl(139_28%_20%)] text-white px-8 py-3 text-lg rounded-lg transition-all duration-200 hover:shadow-lg hover:scale-105">
-              Get Started
+            <Button
+              asChild
+              className="bg-forest-green dark:bg-[hsl(139_28%_25%)] hover:bg-forest-green/90 dark:hover:bg-[hsl(139_28%_20%)] text-white px-8 py-3 text-lg rounded-lg transition-all duration-200 hover:shadow-lg hover:scale-105"
+            >
+              <a href="#contact">Get Started</a>
             </Button>
-            <Button variant="outline" className="border-earth-brown text-earth-brown hover:bg-earth-brown dark:hover:bg-[hsl(24_25%_38%)] hover:text-white px-8 py-3 text-lg rounded-lg transition-all duration-200">
-              Request Consultation
+            <Button
+              asChild
+              variant="outline"
+              className="border-earth-brown text-earth-brown hover:bg-earth-brown dark:hover:bg-[hsl(24_25%_38%)] hover:text-white px-8 py-3 text-lg rounded-lg transition-all duration-200"
+            >
+              <a href="#contact">Request Consultation</a>
             </Button>
           </div>
 


### PR DESCRIPTION
## Summary
- Hook up Hero section call-to-action buttons to the contact section so "Get Started" and "Request Consultation" scroll to the contact form.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 39 problems in existing code)*
- `npx eslint src/components/Hero.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689c1e14529083248fa6602eaaa46624