### PR TITLE
Smooth learn more expansion animations

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -168,7 +168,7 @@ const Services = () => {
                         <div className="w-2 h-2 bg-sage rounded-full mt-2"></div>
                         <div>
                           <span className="font-medium">{feature.title}</span>
-                          <CollapsibleContent className="text-sm text-slate-gray/90 mt-1 overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+                          <CollapsibleContent className="text-sm text-slate-gray/90 mt-1 overflow-hidden transition-all duration-300 ease-in-out data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
                             {feature.description}
                           </CollapsibleContent>
                         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -79,28 +79,32 @@ export default {
 				md: 'calc(var(--radius) - 2px)',
 				sm: 'calc(var(--radius) - 4px)'
 			},
-			keyframes: {
-				'accordion-down': {
-					from: {
-						height: '0'
-					},
-					to: {
-						height: 'var(--radix-accordion-content-height)'
-					}
-				},
-				'accordion-up': {
-					from: {
-						height: 'var(--radix-accordion-content-height)'
-					},
-					to: {
-						height: '0'
-					}
-				},
-				'fade-in-up': {
-					'0%': {
-						opacity: '0',
-						transform: 'translateY(30px)'
-					},
+                        keyframes: {
+                                'accordion-down': {
+                                        from: {
+                                                height: '0',
+                                                opacity: '0'
+                                        },
+                                        to: {
+                                                height: 'var(--radix-accordion-content-height)',
+                                                opacity: '1'
+                                        }
+                                },
+                                'accordion-up': {
+                                        from: {
+                                                height: 'var(--radix-accordion-content-height)',
+                                                opacity: '1'
+                                        },
+                                        to: {
+                                                height: '0',
+                                                opacity: '0'
+                                        }
+                                },
+                                'fade-in-up': {
+                                        '0%': {
+                                                opacity: '0',
+                                                transform: 'translateY(30px)'
+                                        },
 					'100%': {
 						opacity: '1',
 						transform: 'translateY(0)'
@@ -115,13 +119,13 @@ export default {
 					}
 				}
 			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out',
-				'fade-in-up': 'fade-in-up 0.6s ease-out forwards',
-				'fade-in': 'fade-in 0.8s ease-out forwards'
-			}
-		}
-	},
+                        animation: {
+                                'accordion-down': 'accordion-down 0.3s ease-in-out',
+                                'accordion-up': 'accordion-up 0.3s ease-in-out',
+                                'fade-in-up': 'fade-in-up 0.6s ease-out forwards',
+                                'fade-in': 'fade-in 0.8s ease-out forwards'
+                        }
+                }
+        },
         plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- smoothen accordion open/close with fade and longer transitions
- refine Services component to fade in feature descriptions when "Learn More" is opened

## Testing
- `npm run lint` *(fails: Unnecessary escape character, Unexpected any)*
- `npx eslint src/components/Services.tsx tailwind.config.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c2bc873788324805b9ec8b57c0a41