### PR TITLE
fix: maintain bullet size during service card expansion

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -165,7 +165,7 @@ const Services = () => {
                   <ul className="space-y-2 mb-6">
                     {service.features.map((feature, featureIndex) => (
                       <li key={featureIndex} className="flex items-start space-x-2 text-slate-gray">
-                        <div className="w-2 h-2 bg-sage rounded-full mt-2"></div>
+                        <div className="w-2 h-2 bg-sage rounded-full mt-2 flex-shrink-0"></div>
                         <div>
                           <span className="font-medium">{feature.title}</span>
                           <CollapsibleContent className="text-sm text-slate-gray/90 mt-1 overflow-hidden transition-all duration-300 ease-in-out data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">


### PR DESCRIPTION
## Summary
- prevent bullet points from shrinking during Learn More expansion by disabling flex shrink

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 39 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689c2d97a2408324a0ca94f1e89cf1d4