### PR TITLE
feat: unify site animations with scroll reveal

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
+import ScrollReveal from '@/components/ScrollReveal';
 
 const About = () => {
   const values = [
@@ -30,25 +31,25 @@ const About = () => {
     <section id="about" className="py-20 bg-sage/5 dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
-        <div className="text-center mb-16">
+        <ScrollReveal className="text-center mb-16">
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-forest-green mb-4">
             Why RootedAI?
           </h2>
           <p className="text-lg sm:text-xl text-slate-gray max-w-3xl mx-auto">
             We understand that small businesses need AI solutions that are practical, affordable, and aligned with their values.
           </p>
-        </div>
+        </ScrollReveal>
 
         {/* Mission Statement */}
-        <div className="bg-white dark:bg-slate-900 rounded-2xl p-8 sm:p-12 mb-16 shadow-lg">
+        <ScrollReveal className="bg-white dark:bg-slate-900 rounded-2xl p-8 sm:p-12 mb-16 shadow-lg">
           <div className="max-w-4xl mx-auto text-center">
             <h3 className="text-2xl sm:text-3xl font-bold text-forest-green mb-6">Our Mission</h3>
             <p className="text-lg text-slate-gray leading-relaxed mb-8">
-              To empower small businesses in Kansas City and beyond with practical AI solutions that drive growth 
-              while preserving the personal touch and community values that make them special. We believe that 
+              To empower small businesses in Kansas City and beyond with practical AI solutions that drive growth
+              while preserving the personal touch and community values that make them special. We believe that
               technology should enhance human connection, not replace it.
             </p>
-            
+
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
               <div>
                 <div className="text-3xl font-bold text-earth-brown mb-2">5+</div>
@@ -64,10 +65,10 @@ const About = () => {
               </div>
             </div>
           </div>
-        </div>
+        </ScrollReveal>
 
         {/* Core Values */}
-        <div className="mb-16">
+        <ScrollReveal className="mb-16">
           <h3 className="text-2xl sm:text-3xl font-bold text-forest-green text-center mb-12">
             Our Core Values
           </h3>
@@ -86,10 +87,10 @@ const About = () => {
               </Card>
             ))}
           </div>
-        </div>
+        </ScrollReveal>
 
         {/* Target Market */}
-        <div className="bg-white dark:bg-slate-900 rounded-2xl p-8 sm:p-12 shadow-lg">
+        <ScrollReveal className="bg-white dark:bg-slate-900 rounded-2xl p-8 sm:p-12 shadow-lg">
           <div className="max-w-4xl mx-auto">
             <h3 className="text-2xl sm:text-3xl font-bold text-forest-green text-center mb-8">
               Who We Serve
@@ -147,7 +148,7 @@ const About = () => {
               </div>
             </div>
           </div>
-        </div>
+        </ScrollReveal>
         
       </div>
     </section>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import ScrollReveal from '@/components/ScrollReveal';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuthSecureV2';
@@ -52,32 +53,35 @@ const Contact = () => {
     <section id="contact" className="py-20 bg-sage/5 dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
-        <div className="text-center mb-16">
+        <ScrollReveal className="text-center mb-16">
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-forest-green mb-4">
             Get Rooted Today
           </h2>
           <p className="text-lg sm:text-xl text-slate-gray max-w-3xl mx-auto">
             Ready to explore how AI can help your business grow? Let's start the conversation.
           </p>
-        </div>
+        </ScrollReveal>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
           {/* Contact Form */}
-          <Card className="border-sage/30 shadow-lg h-full flex flex-col">
-            <CardHeader>
-              <CardTitle className="text-2xl text-forest-green">Send us a message</CardTitle>
-            </CardHeader>
-            <CardContent className="flex-grow flex flex-col">
-              <ContactForm />
-            </CardContent>
-          </Card>
+          <ScrollReveal>
+            <Card className="border-sage/30 shadow-lg h-full flex flex-col">
+              <CardHeader>
+                <CardTitle className="text-2xl text-forest-green">Send us a message</CardTitle>
+              </CardHeader>
+              <CardContent className="flex-grow flex flex-col">
+                <ContactForm />
+              </CardContent>
+            </Card>
+          </ScrollReveal>
 
           {/* Contact Information & CTA */}
           <div className="space-y-8">
             {/* Contact Details */}
-            <Card className="border-sage/30 dark:bg-slate-900 shadow-lg">
-              <CardContent className="p-8">
-                <h3 className="text-xl font-semibold text-forest-green mb-6">Get in Touch</h3>
+            <ScrollReveal>
+              <Card className="border-sage/30 dark:bg-slate-900 shadow-lg">
+                <CardContent className="p-8">
+                  <h3 className="text-xl font-semibold text-forest-green mb-6">Get in Touch</h3>
                 <div className="space-y-4">
                   <div className="flex items-center space-x-3">
                     <div className="w-8 h-8 bg-sage/20 rounded-full flex items-center justify-center">
@@ -111,23 +115,26 @@ const Contact = () => {
             </Card>
 
             {/* Schedule a Workshop */}
-            <Card className="border-forest-green/30 bg-forest-green/5 dark:bg-slate-900 shadow-lg">
-              <CardContent className="p-8 text-center">
-                <h3 className="text-xl font-semibold text-forest-green mb-4">
-                  Ready for a Growth?
-                </h3>
-                <p className="text-slate-gray mb-6">
-                  Skip the form and schedule a free 30-minute discovery call to discuss your AI readiness.
-                </p>
-                <Button className="bg-earth-brown dark:bg-[hsl(24_25%_38%)] hover:bg-earth-brown/90 dark:hover:bg-[hsl(24_25%_33%)] text-white px-6 py-3 rounded-lg transition-all duration-200 hover:shadow-lg">
-                  Schedule Discovery Session
-                </Button>
-              </CardContent>
-            </Card>
+            <ScrollReveal>
+              <Card className="border-forest-green/30 bg-forest-green/5 dark:bg-slate-900 shadow-lg">
+                <CardContent className="p-8 text-center">
+                  <h3 className="text-xl font-semibold text-forest-green mb-4">
+                    Ready for a Growth?
+                  </h3>
+                  <p className="text-slate-gray mb-6">
+                    Skip the form and schedule a free 30-minute discovery call to discuss your AI readiness.
+                  </p>
+                  <Button className="bg-earth-brown dark:bg-[hsl(24_25%_38%)] hover:bg-earth-brown/90 dark:hover:bg-[hsl(24_25%_33%)] text-white px-6 py-3 rounded-lg transition-all duration-200 hover:shadow-lg">
+                    Schedule Discovery Session
+                  </Button>
+                </CardContent>
+              </Card>
+            </ScrollReveal>
 
             {/* Newsletter Signup */}
-            <Card className="border-sage/30 shadow-lg">
-              <CardContent className="p-8">
+            <ScrollReveal>
+              <Card className="border-sage/30 shadow-lg">
+                <CardContent className="p-8">
                 <h3 className="text-xl font-semibold text-forest-green mb-4">
                   Stay Updated
                 </h3>
@@ -185,8 +192,9 @@ const Contact = () => {
                     </Button>
                   </form>
                 )}
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            </ScrollReveal>
           </div>
         </div>
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
+import ScrollReveal from '@/components/ScrollReveal';
 import heroPlantLight from '@/assets/hero-plants-light.jpg';
 import heroPlantDark from '@/assets/hero-plants-dark.jpg';
 
@@ -36,20 +37,24 @@ const Hero = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
         <div className="max-w-4xl mx-auto">
           {/* Main Heading */}
-          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-forest-green dark:text-white mb-6 animate-fade-in-up [text-shadow:_0_2px_8px_rgb(255_255_255_/_0.8)] dark:[text-shadow:_0_2px_8px_rgb(0_0_0_/_0.6)]">
-            Grow Smarter.
-            <br />
-            <span className="text-earth-brown dark:text-sage">Stay Rooted.</span>
-          </h1>
+          <ScrollReveal>
+            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-forest-green dark:text-white mb-6 [text-shadow:_0_2px_8px_rgb(255_255_255_/_0.8)] dark:[text-shadow:_0_2px_8px_rgb(0_0_0_/_0.6)]">
+              Grow Smarter.
+              <br />
+              <span className="text-earth-brown dark:text-sage">Stay Rooted.</span>
+            </h1>
+          </ScrollReveal>
 
           {/* Subheading */}
-          <p className="text-lg sm:text-xl lg:text-2xl text-slate-gray dark:text-muted-foreground mb-8 max-w-3xl mx-auto leading-relaxed animate-fade-in-up [text-shadow:_0_1px_4px_rgb(255_255_255_/_0.9)] dark:[text-shadow:_0_1px_4px_rgb(0_0_0_/_0.5)]" style={{animationDelay: '0.2s'}}>
-            Helping small businesses in Kansas City flourish with AI solutions built on Microsoft tools. 
-            From awareness to adoption, we're your local growth partners.
-          </p>
+          <ScrollReveal delay={200}>
+            <p className="text-lg sm:text-xl lg:text-2xl text-slate-gray dark:text-muted-foreground mb-8 max-w-3xl mx-auto leading-relaxed [text-shadow:_0_1px_4px_rgb(255_255_255_/_0.9)] dark:[text-shadow:_0_1px_4px_rgb(0_0_0_/_0.5)]">
+              Helping small businesses in Kansas City flourish with AI solutions built on Microsoft tools.
+              From awareness to adoption, we're your local growth partners.
+            </p>
+          </ScrollReveal>
 
           {/* CTA Buttons */}
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center animate-fade-in-up" style={{animationDelay: '0.4s'}}>
+          <ScrollReveal delay={400} className="flex flex-col sm:flex-row gap-4 justify-center items-center">
             <Button
               asChild
               className="bg-forest-green dark:bg-[hsl(139_28%_25%)] hover:bg-forest-green/90 dark:hover:bg-[hsl(139_28%_20%)] text-white px-8 py-3 text-lg rounded-lg transition-all duration-200 hover:shadow-lg hover:scale-105"
@@ -63,10 +68,10 @@ const Hero = () => {
             >
               <a href="#contact">Grow With Us</a>
             </Button>
-          </div>
+          </ScrollReveal>
 
           {/* Trust Indicators */}
-          <div className="mt-12 flex flex-col sm:flex-row items-center justify-center space-y-4 sm:space-y-0 sm:space-x-8 text-sm text-slate-gray/90 dark:text-muted-foreground animate-fade-in-up drop-shadow-sm" style={{animationDelay: '0.6s'}}>
+          <ScrollReveal delay={600} className="mt-12 flex flex-col sm:flex-row items-center justify-center space-y-4 sm:space-y-0 sm:space-x-8 text-sm text-slate-gray/90 dark:text-muted-foreground drop-shadow-sm">
             <div className="flex items-center space-x-2">
               <div className="w-4 h-4 bg-forest-green rounded-full shadow-sm"></div>
               <span>Local Kansas City Experts</span>
@@ -79,7 +84,7 @@ const Hero = () => {
               <div className="w-4 h-4 bg-sage rounded-full shadow-sm"></div>
               <span>Small Business Focused</span>
             </div>
-          </div>
+          </ScrollReveal>
         </div>
       </div>
 

--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
+import ScrollReveal from '@/components/ScrollReveal';
 
 const Reviews = () => {
   const testimonials = [
@@ -43,22 +44,21 @@ const Reviews = () => {
     <section id="reviews" className="py-20 bg-cream dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
-        <div className="text-center mb-16 animate-fade-in-up">
+        <ScrollReveal className="text-center mb-16">
           <h2 className="text-4xl lg:text-5xl font-bold text-forest-green mb-6">
             What Our Clients Say
           </h2>
           <p className="text-lg text-slate-gray max-w-3xl mx-auto leading-relaxed">
             Real stories from Kansas City businesses who've embraced AI with our help
           </p>
-        </div>
+        </ScrollReveal>
 
         {/* Testimonials Grid */}
         <div className="grid md:grid-cols-3 gap-8 mb-16">
           {testimonials.map((testimonial, index) => {
             const card = (
               <Card
-                className="bg-white dark:bg-slate-900 shadow-lg hover:shadow-xl transition-all duration-300 border-0 animate-fade-in-up"
-                style={{ animationDelay: `${index * 0.2}s` }}
+                className="bg-white dark:bg-slate-900 shadow-lg hover:shadow-xl transition-all duration-300 border-0"
               >
                 <CardContent className="p-8">
                   {/* Quote Icon */}
@@ -86,24 +86,27 @@ const Reviews = () => {
               </Card>
             );
 
-            return testimonial.company === "The Survey Institute" ? (
-              <a
-                key={index}
-                href="https://surveyinstitute.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block"
-              >
-                {card}
-              </a>
-            ) : (
-              <React.Fragment key={index}>{card}</React.Fragment>
+            return (
+              <ScrollReveal key={index} delay={index * 200}>
+                {testimonial.company === "The Survey Institute" ? (
+                  <a
+                    href="https://surveyinstitute.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block"
+                  >
+                    {card}
+                  </a>
+                ) : (
+                  <React.Fragment>{card}</React.Fragment>
+                )}
+              </ScrollReveal>
             );
           })}
         </div>
 
         {/* Stats Section */}
-        <div className="bg-forest-green dark:bg-[hsl(139_28%_25%)] rounded-2xl p-8 lg:p-12 animate-fade-in-up">
+        <ScrollReveal className="bg-forest-green dark:bg-[hsl(139_28%_25%)] rounded-2xl p-8 lg:p-12">
           <div className="grid md:grid-cols-3 gap-8 text-center">
             {stats.map((stat, index) => (
               <div key={index} className="text-white">
@@ -116,7 +119,7 @@ const Reviews = () => {
               </div>
             ))}
           </div>
-        </div>
+        </ScrollReveal>
       </div>
     </section>
   );

--- a/src/components/ScrollReveal.tsx
+++ b/src/components/ScrollReveal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { useScrollReveal } from '@/hooks/useScrollReveal';
+
+interface ScrollRevealProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  delay?: number;
+}
+
+const ScrollReveal: React.FC<ScrollRevealProps> = ({
+  children,
+  className,
+  delay = 0,
+  ...props
+}) => {
+  const { ref, isVisible } = useScrollReveal<HTMLDivElement>();
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'opacity-0 translate-y-8 transition-all duration-700 ease-out',
+        isVisible && 'opacity-100 translate-y-0',
+        className
+      )}
+      style={{ transitionDelay: `${delay}ms` }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default ScrollReveal;

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import ScrollReveal from '@/components/ScrollReveal';
 import {
   Collapsible,
   CollapsibleContent,
@@ -130,24 +131,24 @@ const Services = () => {
     <section id="services" className="py-20 bg-white dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
-        <div className="text-center mb-16">
+        <ScrollReveal className="text-center mb-16">
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-forest-green mb-4">
             Our Services
           </h2>
           <p className="text-lg sm:text-xl text-slate-gray max-w-3xl mx-auto">
             From initial awareness to full adoption, we guide your AI journey every step of the way
           </p>
-        </div>
+        </ScrollReveal>
 
         {/* Services Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
           {services.map((service, index) => (
-            <Collapsible
-              key={index}
-              open={openStates[index] || false}
-              onOpenChange={(open) => setOpenStates(prev => ({ ...prev, [index]: open }))}
-            >
-              <Card className="border-sage/30 hover:border-forest-green/50 transition-all duration-300 hover:shadow-lg group">
+            <ScrollReveal key={index} delay={index * 100}>
+              <Collapsible
+                open={openStates[index] || false}
+                onOpenChange={(open) => setOpenStates(prev => ({ ...prev, [index]: open }))}
+              >
+                <Card className="border-sage/30 hover:border-forest-green/50 transition-all duration-300 hover:shadow-lg group">
                 <CardHeader>
                   <div className="flex items-center space-x-4 mb-4">
                     <div className="text-4xl">{service.icon}</div>
@@ -187,13 +188,14 @@ const Services = () => {
                     </CollapsibleTrigger>
                   </div>
                 </CardContent>
-              </Card>
-            </Collapsible>
+                </Card>
+              </Collapsible>
+            </ScrollReveal>
           ))}
         </div>
 
         {/* CTA Section */}
-        <div className="text-center bg-sage/10 dark:bg-slate-900 rounded-2xl p-8 sm:p-12">
+        <ScrollReveal className="text-center bg-sage/10 dark:bg-slate-900 rounded-2xl p-8 sm:p-12">
           <h3 className="text-2xl sm:text-3xl font-bold text-forest-green mb-4">
             Ready to Transform Your Business?
           </h3>
@@ -206,7 +208,7 @@ const Services = () => {
           >
             <a href="#contact">Cultivate Your Vision</a>
           </Button>
-        </div>
+        </ScrollReveal>
       </div>
     </section>
   );

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Globe } from 'lucide-react';
+import ScrollReveal from '@/components/ScrollReveal';
 
 const ProfileImage = ({ member, index }: { member: any, index: number }) => {
   const [rotation, setRotation] = useState(0);
@@ -257,20 +258,21 @@ const Team = () => {
     <section id="team" className="py-20 bg-white dark:bg-slate-800">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
-        <div className="text-center mb-16">
+        <ScrollReveal className="text-center mb-16">
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-forest-green mb-4">
             Meet Our Team
           </h2>
           <p className="text-lg sm:text-xl text-slate-gray max-w-3xl mx-auto">
             Local Kansas City experts with deep experience in AI, technology, and small business growth
           </p>
-        </div>
+        </ScrollReveal>
 
         {/* Team Members */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
           {teamMembers.map((member, index) => (
-            <Card key={index} className="border-sage/30 hover:border-forest-green/50 transition-all duration-300 hover:shadow-xl overflow-hidden">
-              <div className="p-8">
+            <ScrollReveal key={index} delay={index * 100}>
+              <Card className="border-sage/30 hover:border-forest-green/50 transition-all duration-300 hover:shadow-xl overflow-hidden">
+                <div className="p-8">
                 {/* Profile Section */}
                 <div className="flex flex-col sm:flex-row items-center sm:items-start space-y-4 sm:space-y-0 sm:space-x-6 mb-6">
                   <ProfileImage member={member} index={index} />
@@ -323,22 +325,23 @@ const Team = () => {
                     ))}
                   </div>
                 </div>
-              </div>
-            </Card>
+                </div>
+              </Card>
+            </ScrollReveal>
           ))}
         </div>
 
         {/* Team Philosophy */}
-        <div className="mt-16 bg-sage/5 dark:bg-slate-900 rounded-2xl p-8 sm:p-12 text-center">
+        <ScrollReveal className="mt-16 bg-sage/5 dark:bg-slate-900 rounded-2xl p-8 sm:p-12 text-center">
           <h3 className="text-2xl sm:text-3xl font-bold text-forest-green mb-6">
             Our Approach
           </h3>
           <p className="text-lg text-slate-gray max-w-4xl mx-auto leading-relaxed">
-            We believe that successful AI implementation requires both technical expertise and human understanding. 
-            Our team combines deep technical knowledge with a genuine commitment to helping small businesses thrive. 
+            We believe that successful AI implementation requires both technical expertise and human understanding.
+            Our team combines deep technical knowledge with a genuine commitment to helping small businesses thrive.
             We're not just consultants—we're your local partners in growth, here to support you every step of the way.
           </p>
-        </div>
+        </ScrollReveal>
       </div>
     </section>
   );

--- a/src/hooks/useScrollReveal.ts
+++ b/src/hooks/useScrollReveal.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useScrollReveal<T extends HTMLElement>(options?: IntersectionObserverInit) {
+  const ref = useRef<T>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+      if (entry.isIntersecting) {
+        setIsVisible(true);
+        observer.disconnect();
+      }
+    }, options ?? { threshold: 0.1 });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [options]);
+
+  return { ref, isVisible };
+}
+
+export default useScrollReveal;


### PR DESCRIPTION
## Summary
- add reusable ScrollReveal component and hook
- apply unified scroll-triggered animations across hero, services, about, team, reviews, and contact sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 53 problems - Unexpected any and others)*

------
https://chatgpt.com/codex/tasks/task_e_689f560772988324b5b5caa02b36e239