### PR TITLE
Increase hero overlay opacity for light mode

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -22,9 +22,9 @@ const Hero = () => {
         }}
       />
       
-      {/* A) Enhanced readability gradient - increased opacity for better text visibility */}
+      {/* A) Enhanced readability gradient - increased opacity by 5% for better text visibility */}
       <div className="absolute inset-0
-        bg-gradient-to-b from-white/95 via-white/85 to-white/50
+        bg-gradient-to-b from-white/100 via-white/90 to-white/55
         dark:from-slate-950/95 dark:via-slate-950/80 dark:to-slate-950/50" />
 
       {/* B) AI dot-grid (data feel) - more prominent */}


### PR DESCRIPTION
## Summary
- Increase hero overlay opacity by 5% for improved text readability in light mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 43 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a11d51ca108324a974d438f00d3d8b