### PR TITLE
Use light hero image in dark mode

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import heroPlantLight from '@/assets/hero-plants-light.jpg';
-import heroPlantDark from '@/assets/hero-plants-dark.jpg';
 
 const Hero = () => {
   return (
@@ -13,12 +12,6 @@ const Hero = () => {
         className="absolute inset-0 bg-cover bg-center bg-no-repeat transition-all duration-300"
         style={{
           backgroundImage: `url(${heroPlantLight})`,
-        }}
-      />
-      <div 
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat opacity-0 dark:opacity-100 transition-all duration-300"
-        style={{
-          backgroundImage: `url(${heroPlantDark})`,
         }}
       />
       


### PR DESCRIPTION
## Summary
- Remove dark hero background and reuse light-mode image for all themes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 63 problems across repository)*
- `npx eslint src/components/Hero.tsx && echo 'Lint OK'`

------
https://chatgpt.com/codex/tasks/task_e_68a3c5fce2948324b1182f0da85dee42