### PR TITLE
Add count-up animation for landing page metrics

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { AnimatedSection } from '@/hooks/useScrollAnimation';
+import { CountUp } from '@/components/ui/count-up';
 
 const About = () => {
   const values = [
@@ -55,15 +56,27 @@ const About = () => {
               
               <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
                 <div className="interactive-scale">
-                  <div className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale">5+</div>
+                  <div className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale">
+                    <CountUp end={5} suffix="+" />
+                  </div>
                   <div className="text-slate-gray">Plug-&-Play AI Solutions</div>
                 </div>
                 <div className="interactive-scale">
-                  <div className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale" style={{animationDelay: '0.2s'}}>25+</div>
+                  <div
+                    className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale"
+                    style={{ animationDelay: '0.2s' }}
+                  >
+                    <CountUp end={25} suffix="+" />
+                  </div>
                   <div className="text-slate-gray">Years Experience</div>
                 </div>
                 <div className="interactive-scale">
-                  <div className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale" style={{animationDelay: '0.4s'}}>1 hr</div>
+                  <div
+                    className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale"
+                    style={{ animationDelay: '0.4s' }}
+                  >
+                    <CountUp end={1} suffix=" hr" />
+                  </div>
                   <div className="text-slate-gray">Average Response Time</div>
                 </div>
               </div>

--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
+import { CountUp } from '@/components/ui/count-up';
 
 const Reviews = () => {
   const testimonials = [
@@ -14,17 +15,20 @@ const Reviews = () => {
   ];
   const stats = [
     {
-      number: "100%",
-      label: "Ready to Deliver"
+      end: 100,
+      suffix: '%',
+      label: 'Ready to Deliver',
     },
     {
-      number: "200+",
-      label: "Hours Saved Weekly"
+      end: 200,
+      suffix: '+',
+      label: 'Hours Saved Weekly',
     },
     {
-      number: "40%",
-      label: "Average Productivity Increase"
-    }
+      end: 40,
+      suffix: '%',
+      label: 'Average Productivity Increase',
+    },
   ];
   const renderStars = (rating) => {
     return [...Array(5)].map((_, i) => (
@@ -107,9 +111,11 @@ const Reviews = () => {
           <div className="grid md:grid-cols-3 gap-8 text-center">
             {stats.map((stat, index) => (
               <div key={index} className="text-white">
-                <div className="text-4xl lg:text-5xl font-bold mb-2 text-sage">
-                  {stat.number}
-                </div>
+                <CountUp
+                  end={stat.end}
+                  suffix={stat.suffix}
+                  className="text-4xl lg:text-5xl font-bold mb-2 text-sage"
+                />
                 <div className="text-lg font-medium opacity-90">
                   {stat.label}
                 </div>

--- a/src/components/ui/count-up.tsx
+++ b/src/components/ui/count-up.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+
+export interface CountUpProps extends React.HTMLAttributes<HTMLSpanElement> {
+  end: number
+  duration?: number
+  prefix?: string
+  suffix?: string
+}
+
+export function CountUp({
+  end,
+  duration = 2000,
+  prefix = '',
+  suffix = '',
+  className,
+  ...props
+}: CountUpProps) {
+  const [value, setValue] = React.useState(0)
+
+  React.useEffect(() => {
+    let start: number | null = null
+    const step = (timestamp: number) => {
+      if (!start) start = timestamp
+      const progress = Math.min((timestamp - start) / duration, 1)
+      setValue(Math.floor(progress * end))
+      if (progress < 1) {
+        requestAnimationFrame(step)
+      }
+    }
+    requestAnimationFrame(step)
+  }, [end, duration])
+
+  return (
+    <span className={className} {...props}>
+      {prefix}
+      {value}
+      {suffix}
+    </span>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add reusable `CountUp` component with prefix/suffix support
- animate About and Reviews page metrics for 2 seconds

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 46 errors, 17 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a3ca2843a08324baa48143dcb8d7c5