### PR TITLE
Add hover pop-out animation to team contact cards

### DIFF
--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -269,7 +269,10 @@ const Team = () => {
         {/* Team Members */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
           {teamMembers.map((member, index) => (
-            <Card key={index} className="border-sage/30 hover:border-forest-green/50 transition-all duration-300 hover:shadow-xl overflow-hidden">
+            <Card
+              key={index}
+              className="card-energy border-sage/30 hover:border-forest-green/50 hover:shadow-xl overflow-hidden"
+            >
               <div className="p-8">
                 {/* Profile Section */}
                 <div className="flex flex-col sm:flex-row items-center sm:items-start space-y-4 sm:space-y-0 sm:space-x-6 mb-6">


### PR DESCRIPTION
## Summary
- Apply `card-energy` hover animation to team member cards so James and Phil contact cards pop out like service cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 63 problems, 46 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cab56c808324b098618faf751798