### PR TITLE
Add count-up animation for landing metrics

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { AnimatedSection } from '@/hooks/useScrollAnimation';
+import CountUp from '@/components/CountUp';
 
 const About = () => {
   const values = [
@@ -55,15 +56,27 @@ const About = () => {
               
               <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
                 <div className="interactive-scale">
-                  <div className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale">5+</div>
+                  <div className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale">
+                    <CountUp value="5+" />
+                  </div>
                   <div className="text-slate-gray">Plug-&-Play AI Solutions</div>
                 </div>
                 <div className="interactive-scale">
-                  <div className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale" style={{animationDelay: '0.2s'}}>25+</div>
+                  <div
+                    className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale"
+                    style={{ animationDelay: '0.2s' }}
+                  >
+                    <CountUp value="25+" />
+                  </div>
                   <div className="text-slate-gray">Years Experience</div>
                 </div>
                 <div className="interactive-scale">
-                  <div className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale" style={{animationDelay: '0.4s'}}>1 hr</div>
+                  <div
+                    className="text-3xl font-bold text-earth-brown mb-2 animate-pulse-scale"
+                    style={{ animationDelay: '0.4s' }}
+                  >
+                    <CountUp value="1 hr" />
+                  </div>
                   <div className="text-slate-gray">Average Response Time</div>
                 </div>
               </div>

--- a/src/components/CountUp.tsx
+++ b/src/components/CountUp.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface CountUpProps {
+  value: number | string;
+  durationMs?: number;
+  formatter?: (value: number) => string;
+  className?: string;
+}
+
+const CountUp: React.FC<CountUpProps> = ({ value, durationMs = 1500, formatter, className }) => {
+  // Determine numeric target and formatter based on input
+  let target = 0;
+  let format = formatter;
+
+  if (typeof value === 'string') {
+    const match = value.trim().match(/^([^0-9]*)([0-9]*\.?[0-9]+)(.*)$/);
+    if (match) {
+      const prefix = match[1] ?? '';
+      target = parseFloat(match[2]);
+      const suffix = match[3] ?? '';
+      format = format || ((val: number) => `${prefix}${Math.round(val)}${suffix}`);
+    } else {
+      // Fallback if parsing fails
+      target = Number(value) || 0;
+      format = format || ((val: number) => Math.round(val).toString());
+    }
+  } else {
+    target = value;
+    format = format || ((val: number) => Math.round(val).toString());
+  }
+
+  const [display, setDisplay] = useState<string>(format(0));
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const hasAnimated = useRef(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReduced) {
+      setDisplay(format(target));
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasAnimated.current) {
+          hasAnimated.current = true;
+          const start = performance.now();
+
+          const step = (now: number) => {
+            const progress = (now - start) / durationMs;
+            const clamped = Math.min(progress, 1);
+            const current = target * clamped;
+            setDisplay(format(current));
+            if (clamped < 1) {
+              requestAnimationFrame(step);
+            }
+          };
+
+          requestAnimationFrame(step);
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, [target, durationMs, format]);
+
+  return (
+    <span ref={ref} className={className}>
+      {display}
+    </span>
+  );
+};
+
+export default CountUp;

--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
+import CountUp from '@/components/CountUp';
 
 const Reviews = () => {
   const testimonials = [
@@ -108,7 +109,7 @@ const Reviews = () => {
             {stats.map((stat, index) => (
               <div key={index} className="text-white">
                 <div className="text-4xl lg:text-5xl font-bold mb-2 text-sage">
-                  {stat.number}
+                  <CountUp value={stat.number} />
                 </div>
                 <div className="text-lg font-medium opacity-90">
                   {stat.label}


### PR DESCRIPTION
## Summary
- add reusable `CountUp` component with intersection observer and reduced-motion support
- animate numeric metrics in About and Reviews sections using `CountUp`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: existing eslint errors across repo)*
- `npx eslint src/components/CountUp.tsx src/components/About.tsx src/components/Reviews.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a3cd7a404c83249134e456dacb4d86