### PR TITLE
fix: show splash screen only on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -332,3 +332,9 @@
   @apply w-32 h-32;
   animation: splashIn 1.5s ease-in-out forwards;
 }
+
+@media (min-width: 768px) {
+  #splash-screen {
+    display: none;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,11 @@ root.render(
 
 const splash = document.getElementById('splash-screen');
 if (splash) {
-  // Allow the splash animation to play before removing
-  setTimeout(() => splash.remove(), 1500);
+  const isMobile = window.matchMedia('(max-width: 767px)').matches;
+  if (isMobile) {
+    // Allow the splash animation to play before removing
+    setTimeout(() => splash.remove(), 1500);
+  } else {
+    splash.remove();
+  }
 }


### PR DESCRIPTION
## Summary
- hide splash screen on larger screens
- remove splash screen immediately on non-mobile devices

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 46 errors, 17 warnings)*
- `npx eslint src/main.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a3cf8467d48324b594b88507ed6ebe