### PR TITLE
Refine contact form layout

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -62,10 +62,10 @@ const Contact = () => {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 max-w-6xl mx-auto">
           {/* Contact Form */}
           <Card className="border-sage/30 shadow-lg h-full flex flex-col">
-            <CardHeader>
+            <CardHeader className="flex flex-col space-y-1.5 p-6 pb-0">
               <CardTitle className="text-2xl text-forest-green">Send us a message</CardTitle>
             </CardHeader>
-            <CardContent className="flex-grow flex flex-col">
+            <CardContent className="flex flex-col flex-1">
               <ContactForm />
             </CardContent>
           </Card>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -126,79 +126,80 @@ const ContactForm = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6 flex flex-col h-full">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <form onSubmit={handleSubmit} className="flex flex-col h-full">
+      <div className="flex flex-col flex-1 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
+              Name *
+            </label>
+            <Input
+              id="name"
+              type="text"
+              value={formData.name}
+              onChange={(e) => handleInputChange('name', e.target.value)}
+              required
+              className="w-full"
+              maxLength={100}
+            />
+          </div>
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+              Email *
+            </label>
+            <Input
+              id="email"
+              type="email"
+              value={formData.email}
+              onChange={(e) => handleInputChange('email', e.target.value)}
+              required
+              className="w-full"
+              maxLength={254}
+            />
+          </div>
+        </div>
+
         <div>
-          <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
-            Name *
+          <label htmlFor="service_type" className="block text-sm font-medium text-gray-700 mb-2">
+            Service Interest
           </label>
-          <Input
-            id="name"
-            type="text"
-            value={formData.name}
-            onChange={(e) => handleInputChange('name', e.target.value)}
-            required
-            className="w-full"
-            maxLength={100}
-          />
+          <Select value={formData.service_type} onValueChange={(value) => handleInputChange('service_type', value)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a service (optional)" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ai-consultation">AI Consultation</SelectItem>
+              <SelectItem value="automation">Process Automation</SelectItem>
+              <SelectItem value="analytics">Data Analytics</SelectItem>
+              <SelectItem value="training">AI Training</SelectItem>
+              <SelectItem value="other">Other</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
-        <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-            Email *
+
+        <div className="flex-1 flex flex-col">
+          <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
+            Message *
           </label>
-          <Input
-            id="email"
-            type="email"
-            value={formData.email}
-            onChange={(e) => handleInputChange('email', e.target.value)}
+          <Textarea
+            id="message"
+            value={formData.message}
+            onChange={(e) => handleInputChange('message', e.target.value)}
             required
-            className="w-full"
-            maxLength={254}
+            className="w-full flex-1 min-h-[150px] resize-none"
+            placeholder="Tell us about your project or how we can help..."
+            maxLength={5000}
           />
+          <div className="text-sm text-gray-500 mt-1">
+            {formData.message.length}/5000 characters
+          </div>
         </div>
       </div>
-      
-      <div>
-        <label htmlFor="service_type" className="block text-sm font-medium text-gray-700 mb-2">
-          Service Interest
-        </label>
-        <Select value={formData.service_type} onValueChange={(value) => handleInputChange('service_type', value)}>
-          <SelectTrigger>
-            <SelectValue placeholder="Select a service (optional)" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="ai-consultation">AI Consultation</SelectItem>
-            <SelectItem value="automation">Process Automation</SelectItem>
-            <SelectItem value="analytics">Data Analytics</SelectItem>
-            <SelectItem value="training">AI Training</SelectItem>
-            <SelectItem value="other">Other</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      
-      <div>
-        <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
-          Message *
-        </label>
-        <Textarea
-          id="message"
-          value={formData.message}
-          onChange={(e) => handleInputChange('message', e.target.value)}
-          required
-          rows={8}
-          className="w-full min-h-[150px] resize-y"
-          placeholder="Tell us about your project or how we can help..."
-          maxLength={5000}
-        />
-        <div className="text-sm text-gray-500 mt-1">
-          {formData.message.length}/5000 characters
-        </div>
-      </div>
-      
+
       <Button
         type="submit"
         disabled={isSubmitting}
-        className="w-full bg-forest-green hover:bg-forest-green/90 mt-auto"
+        className="w-full bg-forest-green hover:bg-forest-green/90 mt-6"
       >
         {isSubmitting ? 'Sending...' : 'Send Message'}
       </Button>


### PR DESCRIPTION
## Summary
- Stretch contact form card to fill vertical space with consistent inner padding
- Rework form fields and textarea to grow and keep the Send Message button pinned to the bottom

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any...)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3d682cdd48324bbb28ad95c4e57bc