### PR TITLE
fix: remove session check timeout for admin access

### DIFF
--- a/src/hooks/useAuthReliable.tsx
+++ b/src/hooks/useAuthReliable.tsx
@@ -259,17 +259,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           if (timeoutId) clearTimeout(timeoutId);
         };
 
-        // Check for existing session with timeout
-        const sessionPromise = supabase.auth.getSession();
-        const timeoutPromise = new Promise((_, reject) => 
-          setTimeout(() => reject(new Error('Session check timeout')), 20000)
-        );
+        // Check for existing session without racing timeouts to avoid false negatives
+        const {
+          data: { session },
+          error
+        } = await supabase.auth.getSession();
 
-        const { data: { session }, error } = await Promise.race([
-          sessionPromise,
-          timeoutPromise
-        ]) as any;
-        
         if (error) {
           console.warn('Session check error:', error);
           clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
- Avoid racing auth session checks with a manual timeout
- Ensure admins can load company portals without spurious authentication errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, no-useless-escape, no-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e1db07a48324bbb98ddc88de63e8