### PR TITLE
Fix company portal redirect and auth guard timeout

### DIFF
--- a/src/components/FastAuthGuard.tsx
+++ b/src/components/FastAuthGuard.tsx
@@ -29,12 +29,19 @@ const FastAuthGuard: React.FC<FastAuthGuardProps> = ({
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       if (loading && !shouldRender) {
-        console.warn('⚠️ FastAuthGuard timeout after 12 seconds');
+        console.warn('⚠️ FastAuthGuard timeout after 30 seconds');
         setTimeoutReached(true);
       }
-    }, 12000);
+    }, 30000);
 
     return () => clearTimeout(timeoutId);
+  }, [loading, shouldRender]);
+
+  // Reset timeout flag once loading completes
+  useEffect(() => {
+    if (!loading && shouldRender) {
+      setTimeoutReached(false);
+    }
   }, [loading, shouldRender]);
 
   useEffect(() => {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -55,14 +55,13 @@ const Auth = () => {
           // Check if user has a company and route accordingly
           setTimeout(async () => {
             try {
-              const { data: userCompanies } = await supabase
-                .from('company_memberships')
-                .select('company_id, companies(slug)')
-                .eq('user_id', session.user.id)
-                .limit(1);
-                
-              if (userCompanies && userCompanies.length > 0) {
-                const companySlug = (userCompanies[0].companies as any)?.slug;
+              // Use RPC to fetch companies to avoid missing FK relationships
+              const { data: userCompanies, error } = await supabase.rpc('get_user_companies');
+
+              if (error) {
+                console.error('Error checking user companies:', error);
+              } else if (userCompanies && userCompanies.length > 0) {
+                const companySlug = (userCompanies[0] as any)?.company_slug;
                 if (companySlug) {
                   navigate(`/company/${companySlug}`);
                   return;


### PR DESCRIPTION
## Summary
- use `get_user_companies` RPC for post-login redirect to avoid missing FK errors
- extend FastAuthGuard timeout and reset flag after load to prevent false auth timeouts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e437f4f483248c719002905092ca