### PR TITLE
Redirect admins to dashboard and expose admin portal links

### DIFF
--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -54,7 +54,7 @@ const ProfileMenu = ({ onSignOut }: ProfileMenuProps) => {
         <DropdownMenuSeparator />
         {userRole === 'Client' && (
           <>
-            {/* Rule 2: Clients see only company portal and profile in dropdown */}
+            {/* Clients see only their company portal and profile */}
             {companies && companies.length > 0 && (
               <DropdownMenuItem asChild>
                 <Link to={`/company/${companies[0].slug}`} className="cursor-pointer">
@@ -72,7 +72,24 @@ const ProfileMenu = ({ onSignOut }: ProfileMenuProps) => {
             <DropdownMenuSeparator />
           </>
         )}
-        {/* Rule 3: Admins never see client portals, no profile/company links in dropdown */}
+        {userRole === 'Admin' && (
+          <>
+            {/* Admins see Rooted AI company portal and their profile */}
+            <DropdownMenuItem asChild>
+              <Link to="/company/rooted-ai" className="cursor-pointer">
+                <Building className="mr-2 h-4 w-4" />
+                <span>Rooted AI Portal</span>
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to="/profile" className="cursor-pointer">
+                <User className="mr-2 h-4 w-4" />
+                <span>Profile</span>
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
         <DropdownMenuItem onClick={onSignOut} className="cursor-pointer">
           <LogOut className="mr-2 h-4 w-4" />
           <span>Sign out</span>


### PR DESCRIPTION
## Summary
- Redirect admins to `/admin` after authentication
- Allow admins to browse any client portal
- Expose Rooted AI portal and profile links in admin menu

## Testing
- `npm run lint` *(fails: Unexpected any, no-useless-escape, no-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e676925c8324ab0c47ca35476a4b