### PR TITLE
feat: add client-side cache and RBAC demo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import ClientPortal from "./pages/ClientPortal";
 import CompanyPage from "./pages/CompanyPage";
 import AccessDenied from "./pages/AccessDenied";
 import NotFound from "./pages/NotFound";
+import RBACDemo from "./pages/RBACDemo";
+import RBACGuard from "@/components/RBACGuard";
 
 const AppContent = () => {
   return (
@@ -61,6 +63,16 @@ const AppContent = () => {
         element={
           <FastAuthGuard requiredRoles={["Admin", "Client"]}>
             <CompanyPage />
+          </FastAuthGuard>
+        }
+      />
+      <Route
+        path="/rbac-demo"
+        element={
+          <FastAuthGuard requiredRoles={["Admin", "Client"]}>
+            <RBACGuard page="rbac-demo">
+              <RBACDemo />
+            </RBACGuard>
           </FastAuthGuard>
         }
       />

--- a/src/components/RBACGuard.tsx
+++ b/src/components/RBACGuard.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuthReliable';
+import { canUser, Role } from '@/lib/rbac';
+
+interface RBACGuardProps {
+  page: string;
+  children: React.ReactNode;
+}
+
+const RBACGuard: React.FC<RBACGuardProps> = ({ page, children }) => {
+  const { userRole } = useAuth();
+  const role = (userRole === 'Client' ? 'User' : userRole) as Role | null;
+  const allowed = canUser(role, page);
+
+  if (!allowed) {
+    return <Navigate to="/access-denied" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default RBACGuard;

--- a/src/hooks/useCachedQuery.ts
+++ b/src/hooks/useCachedQuery.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { cacheClient, Strategy } from '@/lib/cacheClient';
+
+interface Options {
+  strategy?: Strategy;
+  ttl?: number;
+  enabled?: boolean;
+}
+
+export function useCachedQuery<T = unknown>(key: string, url: string, options: Options = {}) {
+  const { strategy = 'cache-first', ttl = 60000, enabled = true } = options;
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchData = () => {
+    setLoading(true);
+    cacheClient.fetch<T>(key, url, {}, strategy, ttl)
+      .then(setData)
+      .catch((err) => setError(err as Error))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    if (!enabled) return;
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, url, strategy, ttl, enabled]);
+
+  return { data, loading, error, refetch: fetchData };
+}

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -1,0 +1,25 @@
+import { cacheClient } from '@/lib/cacheClient';
+
+interface MutationOptions {
+  method?: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  invalidate?: string | string[];
+}
+
+export function useMutation<B = unknown, R = unknown>(options: MutationOptions = {}) {
+  const { method = 'POST', invalidate } = options;
+
+  const mutate = async (url: string, body?: B): Promise<R> => {
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) throw new Error(res.statusText);
+    const data: R = await res.json();
+    const keys = Array.isArray(invalidate) ? invalidate : invalidate ? [invalidate] : [];
+    keys.forEach((k) => cacheClient.invalidate(k));
+    return data;
+  };
+
+  return { mutate };
+}

--- a/src/lib/cacheClient.ts
+++ b/src/lib/cacheClient.ts
@@ -1,0 +1,83 @@
+export type Strategy = 'cache-first' | 'network-first' | 'stale-while-revalidate';
+
+interface CacheEntry<T> {
+  data: T;
+  expiry: number;
+  etag?: string;
+}
+
+class CacheClient {
+  private store = new Map<string, CacheEntry<unknown>>();
+
+  async fetch<T>(key: string, url: string, options: RequestInit = {}, strategy: Strategy = 'cache-first', ttl = 60000): Promise<T> {
+    const entry = this.store.get(key);
+    const now = Date.now();
+    const isExpired = entry ? now > entry.expiry : true;
+
+    if (strategy === 'cache-first') {
+      if (entry && !isExpired) {
+        console.info(`[cache] hit ${key}`);
+        return entry.data;
+      }
+      return this.networkFetch<T>(key, url, options, ttl);
+    }
+
+    if (strategy === 'network-first') {
+      try {
+        return await this.networkFetch<T>(key, url, options, ttl);
+      } catch (err) {
+        if (entry && !isExpired) {
+          console.warn(`[cache] network error, using cache for ${key}`);
+          return entry.data;
+        }
+        throw err;
+      }
+    }
+
+    // stale-while-revalidate
+    if (entry && !isExpired) {
+      this.networkFetch<T>(key, url, options, ttl).catch(() => {
+        /* background refresh failure */
+      });
+      console.info(`[cache] stale hit ${key}`);
+      return entry.data;
+    }
+
+    return this.networkFetch<T>(key, url, options, ttl);
+  }
+
+  private async networkFetch<T>(key: string, url: string, options: RequestInit, ttl: number): Promise<T> {
+    const entry = this.store.get(key);
+    const headers = new Headers(options.headers);
+    if (entry?.etag) headers.set('If-None-Match', entry.etag);
+
+    const res = await fetch(url, { ...options, headers });
+    if (res.status === 304 && entry) {
+      console.info(`[cache] revalidated ${key}`);
+      entry.expiry = Date.now() + ttl;
+      this.store.set(key, entry);
+      return entry.data;
+    }
+    if (!res.ok) throw new Error(res.statusText);
+
+    const data = await res.json();
+    const etag = res.headers.get('ETag') || undefined;
+    this.store.set(key, { data, expiry: Date.now() + ttl, etag });
+    console.info(`[cache] updated ${key}`);
+    return data;
+  }
+
+  invalidate(key?: string) {
+    if (key) {
+      this.store.delete(key);
+      console.info(`[cache] invalidated ${key}`);
+    } else {
+      this.store.clear();
+      console.info('[cache] cleared');
+    }
+  }
+}
+
+export const cacheClient = new CacheClient();
+
+export const clearAllCaches = () => cacheClient.invalidate();

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -1,0 +1,63 @@
+export type Role = 'Admin' | 'Manager' | 'User';
+
+type CRUD = 'create' | 'read' | 'update' | 'delete';
+
+interface RolePermissions {
+  pages: Record<string, Role[]>;
+  crud: Record<string, Record<Role, CRUD[]>>;
+}
+
+const roleHierarchy: Record<Role, Role[]> = {
+  Admin: ['Manager', 'User'],
+  Manager: ['User'],
+  User: []
+};
+
+const permissions: RolePermissions = {
+  pages: {
+    dashboard: ['Admin', 'Manager'],
+    reports: ['Admin', 'Manager'],
+    profile: ['Admin', 'Manager', 'User'],
+    'rbac-demo': ['Admin', 'Manager', 'User']
+  },
+  crud: {
+    users: {
+      Admin: ['create', 'read', 'update', 'delete'],
+      Manager: ['read', 'update'],
+      User: ['read']
+    },
+    todos: {
+      Admin: ['create', 'read', 'update', 'delete'],
+      Manager: ['read', 'update'],
+      User: ['read']
+    }
+  }
+};
+
+const hasRole = (role: Role, target: Role): boolean => {
+  if (role === target) return true;
+  const inherits = roleHierarchy[role] || [];
+  return inherits.some(r => hasRole(r, target));
+};
+
+export const canUser = (role: Role | null, page: string): boolean => {
+  if (!role) return false;
+  const allowed = permissions.pages[page] || [];
+  return allowed.some(r => hasRole(role, r));
+};
+
+export const canCRUD = (role: Role | null, resource: string, op: CRUD): boolean => {
+  if (!role) return false;
+  const resourcePerms = permissions.crud[resource];
+  if (!resourcePerms) return false;
+  return Object.entries(resourcePerms).some(([r, ops]) =>
+    hasRole(role, r as Role) && ops.includes(op)
+  );
+};
+
+export const accessiblePages = (role: Role | null): string[] => {
+  if (!role) return [];
+  return Object.entries(permissions.pages)
+    .filter(([, roles]) => roles.some(r => hasRole(role, r)))
+    .map(([page]) => page);
+};

--- a/src/pages/RBACDemo.tsx
+++ b/src/pages/RBACDemo.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/useAuthReliable';
+import { useCachedQuery } from '@/hooks/useCachedQuery';
+import { useMutation } from '@/hooks/useMutation';
+import { canCRUD, Role } from '@/lib/rbac';
+import { cacheClient } from '@/lib/cacheClient';
+
+interface Todo {
+  userId: number;
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+const RBACDemo: React.FC = () => {
+  const { userRole } = useAuth();
+  const role = (userRole === 'Client' ? 'User' : userRole) as Role | null;
+
+  const { data, loading, error, refetch } = useCachedQuery<Todo>(
+    'todo',
+    'https://jsonplaceholder.typicode.com/todos/1',
+    { strategy: 'stale-while-revalidate', ttl: 10000 }
+  );
+
+  const createTodo = useMutation({ method: 'POST', invalidate: 'todo' });
+  const updateTodo = useMutation({ method: 'PUT', invalidate: 'todo' });
+  const deleteTodo = useMutation({ method: 'DELETE', invalidate: 'todo' });
+
+  const canCreate = canCRUD(role, 'todos', 'create');
+  const canUpdate = canCRUD(role, 'todos', 'update');
+  const canDelete = canCRUD(role, 'todos', 'delete');
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">RBAC & Cache Demo</h1>
+      <p className="text-sm text-muted-foreground">Current role: {userRole}</p>
+
+      <div>
+        {loading && <p>Loading...</p>}
+        {error && <p className="text-destructive">{error.message}</p>}
+        {data && (
+          <pre className="bg-muted p-4 rounded-md overflow-auto">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          onClick={() =>
+            createTodo.mutate('https://jsonplaceholder.typicode.com/todos', {
+              title: 'New todo',
+              completed: false
+            })
+          }
+          disabled={!canCreate}
+        >
+          Create
+        </Button>
+        <Button
+          onClick={() =>
+            updateTodo.mutate('https://jsonplaceholder.typicode.com/todos/1', {
+              title: 'Updated',
+              completed: true
+            })
+          }
+          disabled={!canUpdate}
+        >
+          Update
+        </Button>
+        <Button
+          onClick={() =>
+            deleteTodo.mutate('https://jsonplaceholder.typicode.com/todos/1')
+          }
+          disabled={!canDelete}
+          variant="destructive"
+        >
+          Delete
+        </Button>
+        <Button variant="outline" onClick={() => { cacheClient.invalidate('todo'); refetch(); }}>
+          Refresh
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default RBACDemo;


### PR DESCRIPTION
## Summary
- add cache client with cache-first, network-first and stale-while-revalidate strategies
- provide role-based permission helpers and guards
- showcase caching and permissions via RBAC demo page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 66 problems)*
- `npx eslint src/lib/rbac.ts src/lib/cacheClient.ts src/hooks/useCachedQuery.ts src/hooks/useMutation.ts src/components/RBACGuard.tsx src/pages/RBACDemo.tsx src/App.tsx src/hooks/useAuthReliable.tsx`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3edebf84c83249cdeeb4d2408a151