### PR TITLE
feat: add client portal landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,14 @@ const AppContent = () => {
         }
       />
       <Route
+        path="/client-portal"
+        element={
+          <FastAuthGuard requiredRoles={["Client"]}>
+            <ClientPortal />
+          </FastAuthGuard>
+        }
+      />
+      <Route
         path="/company/:slug"
         element={
           <FastAuthGuard requiredRoles={["Admin", "Client"]}>

--- a/src/components/client-portal/AnnouncementCard.tsx
+++ b/src/components/client-portal/AnnouncementCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+
+interface AnnouncementCardProps {
+  title: string;
+  date: string;
+  status?: 'New' | 'Important';
+}
+
+const AnnouncementCard: React.FC<AnnouncementCardProps> = ({ title, date, status }) => {
+  return (
+    <div className="py-2 border-b last:border-b-0">
+      <div className="flex items-center justify-between mb-1">
+        <p className="text-sm font-medium text-slate-700 dark:text-slate-200">{title}</p>
+        {status && (
+          <Badge className="bg-forest-green/10 text-forest-green">{status}</Badge>
+        )}
+      </div>
+      <p className="text-xs text-slate-gray">{date}</p>
+    </div>
+  );
+};
+
+export default AnnouncementCard;

--- a/src/components/client-portal/CoachingCard.tsx
+++ b/src/components/client-portal/CoachingCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import EmptyState from './EmptyState';
+
+interface CoachingCardProps {
+  nextSession?: string;
+}
+
+const CoachingCard: React.FC<CoachingCardProps> = ({ nextSession }) => {
+  if (!nextSession) {
+    return (
+      <EmptyState
+        message="Pick a time to continue your roadmap."
+        actionLabel="Book a 30-min session"
+        actionHref="#"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-slate-gray">Next session: {nextSession}</p>
+      <Button className="bg-forest-green text-white">Book a 30-min session</Button>
+    </div>
+  );
+};
+
+export default CoachingCard;

--- a/src/components/client-portal/EmptyState.tsx
+++ b/src/components/client-portal/EmptyState.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Leaf } from 'lucide-react';
+
+interface EmptyStateProps {
+  message: string;
+  actionLabel?: string;
+  actionHref?: string;
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({ message, actionLabel, actionHref }) => {
+  return (
+    <div className="flex flex-col items-center text-center py-6">
+      <Leaf className="h-8 w-8 text-sage mb-4" />
+      <p className="text-sm text-slate-gray mb-4">{message}</p>
+      {actionLabel && actionHref && (
+        <Button asChild className="bg-forest-green text-white">
+          <a href={actionHref}>{actionLabel}</a>
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/src/components/client-portal/InsightCard.tsx
+++ b/src/components/client-portal/InsightCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { ArrowRight } from 'lucide-react';
+
+interface InsightCardProps {
+  summary: string;
+  timestamp: string;
+}
+
+const InsightCard: React.FC<InsightCardProps> = ({ summary, timestamp }) => {
+  return (
+    <div className="p-3 rounded-lg border border-sage/20 hover:shadow-sm focus-within:ring-2 focus-within:ring-forest-green">
+      <p className="text-sm text-slate-gray mb-2">{summary}</p>
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-slate-gray">{timestamp}</span>
+        <button className="text-sm text-forest-green inline-flex items-center hover:underline">
+          View details
+          <ArrowRight className="h-4 w-4 ml-1" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default InsightCard;

--- a/src/components/client-portal/KPITile.tsx
+++ b/src/components/client-portal/KPITile.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface KPITileProps {
+  label: string;
+  value: string;
+}
+
+const KPITile: React.FC<KPITileProps> = ({ label, value }) => {
+  return (
+    <div className="p-4 bg-white rounded-lg shadow-sm border border-sage/20">
+      <div className="text-xs text-slate-gray mb-1">{label}</div>
+      <div className="text-xl font-bold text-forest-green">{value}</div>
+      <div className="mt-2 h-1.5 bg-sage/20 rounded-full overflow-hidden">
+        <div className="h-full bg-forest-green" style={{ width: '50%' }}></div>
+      </div>
+    </div>
+  );
+};
+
+export default KPITile;

--- a/src/components/client-portal/ResourceCard.tsx
+++ b/src/components/client-portal/ResourceCard.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { ArrowRight } from 'lucide-react';
+
+interface ResourceCardProps {
+  title: string;
+  type: 'Guide' | 'Video' | 'Slide';
+  href?: string;
+}
+
+const ResourceCard: React.FC<ResourceCardProps> = ({ title, type, href }) => {
+  return (
+    <a
+      href={href}
+      className="block p-3 rounded-lg border border-sage/20 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-forest-green"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-sm font-medium text-forest-green">{title}</p>
+        <Badge className="bg-sage/20 text-forest-green">{type}</Badge>
+      </div>
+      <div className="text-sm text-forest-green inline-flex items-center">
+        {href ? 'Open' : 'Start'}
+        <ArrowRight className="h-4 w-4 ml-1" />
+      </div>
+    </a>
+  );
+};
+
+export default ResourceCard;

--- a/src/components/client-portal/TopNav.tsx
+++ b/src/components/client-portal/TopNav.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+interface TopNavProps {
+  company: string;
+}
+
+const TopNav: React.FC<TopNavProps> = ({ company }) => {
+  return (
+    <header className="sticky top-0 z-10 bg-white border-b border-sage/20 px-4 py-2 flex items-center justify-between">
+      <div className="flex items-center space-x-2">
+        <img
+          src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
+          alt="RootedAI Logo"
+          className="w-6 h-6"
+        />
+        <span className="font-bold text-forest-green">RootedAI</span>
+        <span className="text-slate-gray">{company}</span>
+      </div>
+      <Button asChild variant="outline" size="sm" className="text-forest-green">
+        <a href="mailto:support@rootedai.com">Support</a>
+      </Button>
+    </header>
+  );
+};
+
+export default TopNav;


### PR DESCRIPTION
## Summary
- add client-only portal route
- implement minimal client portal landing UI with announcements, resources, insights, coaching, KPIs and FAQ
- add reusable portal components and top navigation

## Testing
- `npm run lint` *(fails: Unexpected any... etc)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3f63aff948324b75b7271733b170c