### PR TITLE
fix: ensure admin company portals load

### DIFF
--- a/src/pages/CompanyPage.tsx
+++ b/src/pages/CompanyPage.tsx
@@ -44,10 +44,10 @@ export default function CompanyPage() {
   });
 
   useEffect(() => {
-    if (!authLoading && user && slug) {
+    if (!authLoading && user && slug && userRole) {
       fetchCompany();
     }
-  }, [user, authLoading, slug]);
+  }, [user, authLoading, slug, userRole, companies]);
 
   const fetchCompany = async () => {
     try {


### PR DESCRIPTION
## Summary
- Fix company page loading for Admins by refetching once role and companies load

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a469ef73788324aee7226b88d00212