### PR TITLE
Move client company settings to slug root path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,20 +67,20 @@ const AppContent = () => {
         }
       />
       <Route
-        path="/company/:slug"
-        element={
-          <FastAuthGuard requiredRoles={["Admin", "Client"]}>
-            <CompanyPage />
-          </FastAuthGuard>
-        }
-      />
-      <Route
         path="/rbac-demo"
         element={
           <FastAuthGuard requiredRoles={["Admin", "Client"]}>
             <RBACGuard page="rbac-demo">
               <RBACDemo />
             </RBACGuard>
+          </FastAuthGuard>
+        }
+      />
+      <Route
+        path="/:slug"
+        element={
+          <FastAuthGuard requiredRoles={["Admin", "Client"]}>
+            <CompanyPage />
           </FastAuthGuard>
         }
       />

--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -57,7 +57,7 @@ const ProfileMenu = ({ onSignOut }: ProfileMenuProps) => {
             {/* Clients see only their company portal and profile */}
             {companies && companies.length > 0 && (
               <DropdownMenuItem asChild>
-                <Link to={`/company/${companies[0].slug}`} className="cursor-pointer">
+                <Link to={`/${companies[0].slug}`} className="cursor-pointer">
                   <Building className="mr-2 h-4 w-4" />
                   <span>Company Portal</span>
                 </Link>
@@ -76,7 +76,7 @@ const ProfileMenu = ({ onSignOut }: ProfileMenuProps) => {
           <>
             {/* Admins see Rooted AI company portal and their profile */}
             <DropdownMenuItem asChild>
-              <Link to="/company/rooted-ai" className="cursor-pointer">
+              <Link to="/rooted-ai" className="cursor-pointer">
                 <Building className="mr-2 h-4 w-4" />
                 <span>Rooted AI Portal</span>
               </Link>

--- a/src/hooks/useAuthOptimized.tsx
+++ b/src/hooks/useAuthOptimized.tsx
@@ -167,8 +167,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
       
       companies.forEach(company => {
-        accessibleRoutes.add(`/company/${company.slug}`);
-        permissions.set(`/company/${company.slug}`, true);
+        accessibleRoutes.add(`/${company.slug}`);
+        permissions.set(`/${company.slug}`, true);
       });
 
       return {

--- a/src/hooks/useAuthReliable.tsx
+++ b/src/hooks/useAuthReliable.tsx
@@ -158,7 +158,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     // Add company portals user has access to
     companies.forEach(company => {
-      routes.push(`/company/${company.slug}`);
+      routes.push(`/${company.slug}`);
     });
 
     return routes;

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -549,7 +549,7 @@ const AdminDashboard: React.FC = () => {
                         </div>
                         <div className="flex gap-2">
                           <Button variant="outline" size="sm" asChild>
-                            <a href={`/company/${company.slug}`} target="_blank" rel="noopener noreferrer">
+                            <a href={`/${company.slug}`} target="_blank" rel="noopener noreferrer">
                               <ExternalLink className="h-3 w-3 mr-1" />
                               View Portal
                             </a>

--- a/src/pages/ClientPortal.tsx
+++ b/src/pages/ClientPortal.tsx
@@ -50,7 +50,7 @@ const ClientPortal: React.FC = () => {
                 <h3 className="text-lg font-semibold text-forest-green">Company Settings</h3>
                 <p className="text-sm text-slate-gray">Manage your company details and information</p>
               </div>
-              <Link to={`/company/${companySlug}`}>
+              <Link to={`/${companySlug}`}>
                 <Button className="bg-forest-green hover:bg-forest-green/90 text-cream">
                   Edit Company Details
                 </Button>

--- a/src/utils/securityMiddleware.ts
+++ b/src/utils/securityMiddleware.ts
@@ -12,9 +12,13 @@ export class SecurityMiddleware {
     }
     
     // Clients have access to specific actions
-    const clientAllowedActions = ['/', '/profile'];
+    const clientAllowedActions = ['/', '/profile', '/client-portal'];
     if (userRole === 'Client') {
-      return clientAllowedActions.includes(action) || action.startsWith('/company/');
+      const reservedPaths = ['/auth', '/admin', '/client-portal', '/rbac-demo', '/access-denied'];
+      return (
+        clientAllowedActions.includes(action) ||
+        (!reservedPaths.includes(action) && /^\/[-a-zA-Z0-9]+$/.test(action))
+      );
     }
     
     return false;


### PR DESCRIPTION
## Summary
- Serve company pages at `/:slug` instead of `/company/:slug`
- Update navigation links, route lists, and security checks for new slug route
- Allow client company portals to open from top-level slug URLs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a529ea68c883249bb056519ba0c5cd