### PR TITLE
Ensure header navigation for company editing page

### DIFF
--- a/src/components/client-portal/TopNav.tsx
+++ b/src/components/client-portal/TopNav.tsx
@@ -1,21 +1,34 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
 
 interface TopNavProps {
   company: string;
+  /**
+   * Optional link for the company name. Defaults to the client portal.
+   */
+  companyLink?: string;
 }
 
-const TopNav: React.FC<TopNavProps> = ({ company }) => {
+const TopNav: React.FC<TopNavProps> = ({ company, companyLink = '/client-portal' }) => {
   return (
     <header className="sticky top-0 z-10 bg-white border-b border-sage/20 px-4 py-2 flex items-center justify-between">
       <div className="flex items-center space-x-2">
-        <img
-          src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
-          alt="RootedAI Logo"
-          className="w-6 h-6"
-        />
-        <span className="font-bold text-forest-green">RootedAI</span>
-        <span className="text-slate-gray">{company}</span>
+        <a href="https://rootedai.tech" className="flex items-center space-x-2">
+          <img
+            src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
+            alt="RootedAI Logo"
+            className="w-6 h-6"
+          />
+          <span className="font-bold text-forest-green">RootedAI</span>
+        </a>
+        {companyLink ? (
+          <Link to={companyLink} className="text-slate-gray">
+            {company}
+          </Link>
+        ) : (
+          <span className="text-slate-gray">{company}</span>
+        )}
       </div>
       <Button asChild variant="outline" size="sm" className="text-forest-green">
         <a href="mailto:support@rootedai.com">Support</a>

--- a/src/pages/CompanyPage.tsx
+++ b/src/pages/CompanyPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams, Navigate } from 'react-router-dom';
+import { useParams, Navigate, Link } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/useAuthReliable';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { toast } from 'sonner';
+import TopNav from '@/components/client-portal/TopNav';
 
 interface CompanySettings {
   description?: string;
@@ -173,20 +174,26 @@ export default function CompanyPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
-      <div className="container mx-auto py-8 px-4">
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-background to-secondary/20">
+      <TopNav company={company.name} />
+      <div className="container mx-auto py-8 px-4 flex-1">
         <div className="max-w-4xl mx-auto">
           <div className="flex justify-between items-center mb-8">
             <div>
               <h1 className="text-3xl font-bold">{company.name}</h1>
               <p className="text-muted-foreground">Company Dashboard</p>
             </div>
-            <Button 
-              onClick={() => editing ? handleSave() : setEditing(true)}
-              variant={editing ? "default" : "outline"}
-            >
-              {editing ? 'Save Changes' : 'Edit Details'}
-            </Button>
+            <div className="flex gap-2">
+              <Link to="/client-portal">
+                <Button variant="outline">Back to Client Portal</Button>
+              </Link>
+              <Button
+                onClick={() => (editing ? handleSave() : setEditing(true))}
+                variant={editing ? 'default' : 'outline'}
+              >
+                {editing ? 'Save Changes' : 'Edit Details'}
+              </Button>
+            </div>
           </div>
 
           <div className="grid gap-6">


### PR DESCRIPTION
## Summary
- Link RootedAI logo and text in client header to the RootedAI website
- Make the client name in the header link back to the client portal
- Reuse the client portal header on the company edit page with a Back to Client Portal button

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 49 errors, 17 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a52cff5e2083249d5d48e04876ccf5