### PR TITLE
Fix navigation delay returning from client portal

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -78,14 +78,14 @@ const Header = () => {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16 lg:h-20">
             {/* Logo */}
-            <a href="#home" className="flex items-center space-x-2">
+            <Link to="/" className="flex items-center space-x-2">
               <img
                 src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
                 alt="RootedAI Logo"
                 className="w-8 h-8"
               />
               <span className="text-xl lg:text-2xl font-bold text-forest-green">RootedAI</span>
-            </a>
+            </Link>
 
             {/* Desktop Navigation */}
             <nav className="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- Render public routes immediately in `FastAuthGuard` to avoid long loading spinners
- Use router `Link` for site logo so users return to home page without hash navigation

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors across project)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52eff3fac8324853c479a08bcd4a9