### PR TITLE
Link header company name to client portal

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -81,21 +81,32 @@ const Header = () => {
       >
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16 lg:h-20">
-            {/* Logo */}
-            <Link to="/" className="flex items-center space-x-2">
-              <img
-                src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
-                alt="RootedAI Logo"
-                className="w-8 h-8"
-              />
-              <span className="text-xl lg:text-2xl font-bold text-forest-green">RootedAI</span>
+            {/* Logo and company link */}
+            <div className="flex items-center space-x-2">
+              <Link to="/" className="flex items-center space-x-2">
+                <img
+                  src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
+                  alt="RootedAI Logo"
+                  className="w-8 h-8"
+                />
+                <span className="text-xl lg:text-2xl font-bold text-forest-green">RootedAI</span>
+              </Link>
               {companyName && (
                 <>
                   <span className="text-slate-gray">•</span>
-                  <span className="text-slate-gray">{companyName}</span>
+                  {userRole === 'Client' ? (
+                    <a
+                      href="https://rootedai.tech/client-portal"
+                      className="text-slate-gray hover:text-forest-green transition-colors duration-200"
+                    >
+                      {companyName}
+                    </a>
+                  ) : (
+                    <span className="text-slate-gray">{companyName}</span>
+                  )}
                 </>
               )}
-            </Link>
+            </div>
 
             {/* Desktop Navigation */}
             <nav className="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- Make client company name in the header link to the RootedAI client portal when authenticated

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 66 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a53713700883249996ef1d340ca6aa