### PR TITLE
Allow admins to navigate client portals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ const AppContent = () => {
       <Route
         path="/client-portal"
         element={
-          <FastAuthGuard requiredRoles={["Client"]}>
+          <FastAuthGuard requiredRoles={["Client", "Admin"]}>
             <ClientPortal />
           </FastAuthGuard>
         }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,7 @@ import ProfileMenu from './ProfileMenu';
 import { useAuth } from '@/hooks/useAuthReliable';
 import { SimpleMenuManager } from '@/utils/simpleMenuUtils';
 import { usePWAInstall } from '@/hooks/usePWAInstall';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
 
 const Header = () => {
@@ -23,12 +23,20 @@ const Header = () => {
   
   const { user, userRole, signOut, companies } = useAuth();
   const location = useLocation();
+  const [searchParams] = useSearchParams();
   const { isInstallable, isInstalled, installApp } = usePWAInstall();
   const { toast } = useToast();
 
-  const companyName = userRole && companies && companies.length > 0
-    ? companies[0].name
-    : null;
+  let companyName: string | null = null;
+  if (userRole && companies && companies.length > 0) {
+    if (userRole === 'Admin') {
+      const companyParam = searchParams.get('company');
+      const matched = companies.find(c => c.slug === companyParam);
+      companyName = matched?.name || null;
+    } else {
+      companyName = companies[0].name;
+    }
+  }
 
   useEffect(() => {
     const handleScroll = () => {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -17,6 +17,7 @@ import Footer from '@/components/Footer';
 import { LoadingSpinner, InlineLoader } from '@/components/LoadingSpinner';
 import InviteUserForm from '@/components/InviteUserForm';
 import AccessDenied from './AccessDenied';
+import { Link } from 'react-router-dom';
 
 interface UserWithRole {
   id: string;
@@ -549,10 +550,10 @@ const AdminDashboard: React.FC = () => {
                         </div>
                         <div className="flex gap-2">
                           <Button variant="outline" size="sm" asChild>
-                            <a href={`/${company.slug}`} target="_blank" rel="noopener noreferrer">
+                            <Link to={`/client-portal?company=${company.slug}`}>
                               <ExternalLink className="h-3 w-3 mr-1" />
                               View Portal
-                            </a>
+                            </Link>
                           </Button>
                         </div>
                       </div>

--- a/src/pages/ClientPortal.tsx
+++ b/src/pages/ClientPortal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuthReliable';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import AccessDenied from './AccessDenied';
 import Header from '@/components/Header';
 import AnnouncementCard from '@/components/client-portal/AnnouncementCard';
@@ -14,7 +14,12 @@ import EmptyState from '@/components/client-portal/EmptyState';
 
 const ClientPortal: React.FC = () => {
   const { user, userRole, companies, loading } = useAuth();
-  const companySlug = companies[0]?.slug;
+  const [searchParams] = useSearchParams();
+  const companyParam = searchParams.get('company');
+  const company = companyParam
+    ? companies.find(c => c.slug === companyParam)
+    : companies[0];
+  const companySlug = company?.slug;
 
   if (loading) {
     return (
@@ -22,7 +27,11 @@ const ClientPortal: React.FC = () => {
     );
   }
 
-  if (!user || userRole !== 'Client') {
+  if (!user || (userRole !== 'Client' && userRole !== 'Admin')) {
+    return <AccessDenied />;
+  }
+
+  if (!company) {
     return <AccessDenied />;
   }
 


### PR DESCRIPTION
## Summary
- allow `/client-portal` route for admins and read company from query string
- link company cards in the admin dashboard to the client portal inside the app
- show the selected company name for admins when viewing a client portal

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 66 problems)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a537bcdd7883249d42d60b43fd1252