### PR TITLE
Link company name in header to client portal

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -90,20 +90,31 @@ const Header = () => {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16 lg:h-20">
             {/* Logo */}
-            <Link to="/" className="flex items-center space-x-2">
-              <img
-                src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
-                alt="RootedAI Logo"
-                className="w-8 h-8"
-              />
-              <span className="text-xl lg:text-2xl font-bold text-forest-green">RootedAI</span>
+            <div className="flex items-center space-x-2">
+              <Link to="/" className="flex items-center space-x-2">
+                <img
+                  src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
+                  alt="RootedAI Logo"
+                  className="w-8 h-8"
+                />
+                <span className="text-xl lg:text-2xl font-bold text-forest-green">RootedAI</span>
+              </Link>
               {companyName && (
                 <>
                   <span className="text-slate-gray">•</span>
-                  <span className="text-slate-gray">{companyName}</span>
+                  {userRole === 'Client' ? (
+                    <Link
+                      to="/client-portal"
+                      className="text-slate-gray hover:text-forest-green transition-colors duration-200"
+                    >
+                      {companyName}
+                    </Link>
+                  ) : (
+                    <span className="text-slate-gray">{companyName}</span>
+                  )}
                 </>
               )}
-            </Link>
+            </div>
 
             {/* Desktop Navigation */}
             <nav className="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- Make company name in header link to `/client-portal` for authenticated clients

## Testing
- `npm run lint` *(fails: Unexpected any, Empty block statements, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a53a43c83083248348435f7855bce6