### PR TITLE
feat: add admin controls for client portal widgets

### DIFF
--- a/src/pages/ClientPortal.tsx
+++ b/src/pages/ClientPortal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Plus, Pencil, Trash } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuthReliable';
 import { Link, useSearchParams } from 'react-router-dom';
 import AccessDenied from './AccessDenied';
@@ -70,8 +71,21 @@ const ClientPortal: React.FC = () => {
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
           {/* Announcements */}
           <Card className="flex flex-col">
-            <CardHeader>
+            <CardHeader className="flex items-center justify-between">
               <CardTitle className="text-forest-green">Announcements</CardTitle>
+              {userRole === 'Admin' && (
+                <div className="flex space-x-2">
+                  <Button size="icon" variant="ghost" aria-label="Add announcement">
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Edit announcement">
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Delete announcement">
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
             </CardHeader>
             <CardContent className="flex-1">
               {announcements.length ? (
@@ -89,8 +103,21 @@ const ClientPortal: React.FC = () => {
 
           {/* Training & Resources */}
           <Card className="flex flex-col">
-            <CardHeader>
+            <CardHeader className="flex items-center justify-between">
               <CardTitle className="text-forest-green">Training & Resources</CardTitle>
+              {userRole === 'Admin' && (
+                <div className="flex space-x-2">
+                  <Button size="icon" variant="ghost" aria-label="Add resource">
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Edit resource">
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Delete resource">
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
             </CardHeader>
             <CardContent className="flex-1 space-y-3">
               {resources.length ? (
@@ -108,8 +135,21 @@ const ClientPortal: React.FC = () => {
 
           {/* Agent Insights */}
           <Card className="flex flex-col">
-            <CardHeader>
+            <CardHeader className="flex items-center justify-between">
               <CardTitle className="text-forest-green">Agent Insights</CardTitle>
+              {userRole === 'Admin' && (
+                <div className="flex space-x-2">
+                  <Button size="icon" variant="ghost" aria-label="Add insight">
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Edit insight">
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Delete insight">
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
             </CardHeader>
             <CardContent className="flex-1 space-y-3">
               {insights.length ? (
@@ -127,8 +167,21 @@ const ClientPortal: React.FC = () => {
 
           {/* Adoption Coaching */}
           <Card className="flex flex-col">
-            <CardHeader>
+            <CardHeader className="flex items-center justify-between">
               <CardTitle className="text-forest-green">Adoption Coaching</CardTitle>
+              {userRole === 'Admin' && (
+                <div className="flex space-x-2">
+                  <Button size="icon" variant="ghost" aria-label="Add coaching session">
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Edit coaching session">
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Delete coaching session">
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
             </CardHeader>
             <CardContent className="flex-1 flex items-center">
               <CoachingCard nextSession={nextSession} />
@@ -139,8 +192,21 @@ const ClientPortal: React.FC = () => {
         {/* Secondary Row */}
         <div className="grid gap-6 md:grid-cols-2">
           <Card className="flex flex-col">
-            <CardHeader>
+            <CardHeader className="flex items-center justify-between">
               <CardTitle className="text-forest-green">Reports & KPIs</CardTitle>
+              {userRole === 'Admin' && (
+                <div className="flex space-x-2">
+                  <Button size="icon" variant="ghost" aria-label="Add KPI">
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Edit KPI">
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Delete KPI">
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
             </CardHeader>
             <CardContent className="grid grid-cols-2 gap-4">
               <KPITile label="Hours saved" value="0h" />
@@ -149,8 +215,21 @@ const ClientPortal: React.FC = () => {
           </Card>
 
           <Card className="flex flex-col">
-            <CardHeader>
+            <CardHeader className="flex items-center justify-between">
               <CardTitle className="text-forest-green">FAQ</CardTitle>
+              {userRole === 'Admin' && (
+                <div className="flex space-x-2">
+                  <Button size="icon" variant="ghost" aria-label="Add FAQ">
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Edit FAQ">
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button size="icon" variant="ghost" aria-label="Delete FAQ">
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
             </CardHeader>
             <CardContent>
               <EmptyState message="Short answers coming soon." />

--- a/supabase/migrations/20250820070000_client_portal_widgets.sql
+++ b/supabase/migrations/20250820070000_client_portal_widgets.sql
@@ -1,0 +1,160 @@
+-- Client portal widget tables for announcements, resources, insights, coaching, reports & KPIs, and FAQs
+-- Shared tables with company-specific content
+
+-- Announcements
+CREATE TABLE IF NOT EXISTS public.announcements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  content TEXT,
+  status TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.announcements ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage all announcements"
+ON public.announcements FOR ALL
+USING (is_admin());
+
+CREATE POLICY "Users can view company announcements"
+ON public.announcements FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM company_memberships cm
+    WHERE cm.company_id = announcements.company_id
+      AND cm.user_id = auth.uid()
+  )
+);
+
+-- Training & Resources
+CREATE TABLE IF NOT EXISTS public.training_resources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  type TEXT,
+  href TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.training_resources ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage all training_resources"
+ON public.training_resources FOR ALL
+USING (is_admin());
+
+CREATE POLICY "Users can view company training_resources"
+ON public.training_resources FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM company_memberships cm
+    WHERE cm.company_id = training_resources.company_id
+      AND cm.user_id = auth.uid()
+  )
+);
+
+-- Agent Insights
+CREATE TABLE IF NOT EXISTS public.agent_insights (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  summary TEXT NOT NULL,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.agent_insights ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage all agent_insights"
+ON public.agent_insights FOR ALL
+USING (is_admin());
+
+CREATE POLICY "Users can view company agent_insights"
+ON public.agent_insights FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM company_memberships cm
+    WHERE cm.company_id = agent_insights.company_id
+      AND cm.user_id = auth.uid()
+  )
+);
+
+-- Adoption Coaching
+CREATE TABLE IF NOT EXISTS public.adoption_coaching (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  next_session TIMESTAMP WITH TIME ZONE,
+  notes TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.adoption_coaching ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage all adoption_coaching"
+ON public.adoption_coaching FOR ALL
+USING (is_admin());
+
+CREATE POLICY "Users can view company adoption_coaching"
+ON public.adoption_coaching FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM company_memberships cm
+    WHERE cm.company_id = adoption_coaching.company_id
+      AND cm.user_id = auth.uid()
+  )
+);
+
+-- Reports & KPIs
+CREATE TABLE IF NOT EXISTS public.reports_kpis (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  value TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.reports_kpis ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage all reports_kpis"
+ON public.reports_kpis FOR ALL
+USING (is_admin());
+
+CREATE POLICY "Users can view company reports_kpis"
+ON public.reports_kpis FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM company_memberships cm
+    WHERE cm.company_id = reports_kpis.company_id
+      AND cm.user_id = auth.uid()
+  )
+);
+
+-- FAQs
+CREATE TABLE IF NOT EXISTS public.faqs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  question TEXT NOT NULL,
+  answer TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.faqs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can manage all faqs"
+ON public.faqs FOR ALL
+USING (is_admin());
+
+CREATE POLICY "Users can view company faqs"
+ON public.faqs FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM company_memberships cm
+    WHERE cm.company_id = faqs.company_id
+      AND cm.user_id = auth.uid()
+  )
+);


### PR DESCRIPTION
## Summary
- show add/edit/delete buttons for client portal widgets when user is an admin
- define Supabase tables for portal widgets with company scoping

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 49 errors, 17 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a53b537b5083248dc1848e49101293