### PR TITLE
feat: add sortable admin tables

### DIFF
--- a/src/components/admin/SortableTable.tsx
+++ b/src/components/admin/SortableTable.tsx
@@ -1,0 +1,80 @@
+import React, { useState, useMemo } from 'react';
+import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+export interface Column<T> {
+  key: string;
+  label: string;
+  render?: (item: T) => React.ReactNode;
+  sortable?: boolean;
+}
+
+interface SortableTableProps<T> {
+  data: T[];
+  columns: Column<T>[];
+}
+
+function get(obj: any, path: string) {
+  return path.split('.').reduce((o, p) => (o ? o[p] : ''), '') ?? '';
+}
+
+export function SortableTable<T extends { id: string }>({ data, columns }: SortableTableProps<T>) {
+  const [sortKey, setSortKey] = useState<string>(columns[0]?.key);
+  const [asc, setAsc] = useState(true);
+
+  const sorted = useMemo(() => {
+    const items = [...data];
+    if (sortKey) {
+      items.sort((a, b) => {
+        const aVal = get(a, sortKey);
+        const bVal = get(b, sortKey);
+        if (aVal < bVal) return asc ? -1 : 1;
+        if (aVal > bVal) return asc ? 1 : -1;
+        return 0;
+      });
+    }
+    return items;
+  }, [data, sortKey, asc]);
+
+  const handleSort = (key: string) => {
+    if (sortKey === key) {
+      setAsc(!asc);
+    } else {
+      setSortKey(key);
+      setAsc(true);
+    }
+  };
+
+  return (
+    <ScrollArea className="h-52">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {columns.map(col => (
+              <TableHead
+                key={col.key}
+                onClick={() => col.sortable !== false && handleSort(col.key)}
+                className={col.sortable === false ? '' : 'cursor-pointer select-none'}
+              >
+                {col.label}{sortKey === col.key && (asc ? ' ▲' : ' ▼')}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sorted.map(item => (
+            <TableRow key={item.id}>
+              {columns.map(col => (
+                <TableCell key={col.key}>
+                  {col.render ? col.render(item) : get(item, col.key)}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ScrollArea>
+  );
+}
+
+export default SortableTable;


### PR DESCRIPTION
## Summary
- add reusable SortableTable component with scroll and sorting
- switch admin content widgets to sortable tables with client popups

## Testing
- `npm run lint` (fails: Unexpected any. Specify a different type)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a54410e38c8324bf9a4a39aadd0622