### PR TITLE
Fix table getter to display full entry data

### DIFF
--- a/src/components/admin/SortableTable.tsx
+++ b/src/components/admin/SortableTable.tsx
@@ -14,8 +14,10 @@ interface SortableTableProps<T> {
   columns: Column<T>[];
 }
 
-function get(obj: any, path: string) {
-  return path.split('.').reduce((o, p) => (o ? o[p] : ''), '') ?? '';
+function get(obj: unknown, path: string) {
+  return path
+    .split('.')
+    .reduce<unknown>((o, p) => (typeof o === 'object' && o !== null ? (o as Record<string, unknown>)[p] : undefined), obj) ?? '';
 }
 
 export function SortableTable<T extends { id: string }>({ data, columns }: SortableTableProps<T>) {


### PR DESCRIPTION
## Summary
- ensure SortableTable's `get` helper traverses data objects correctly so rows show all column values

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 66 problems, 49 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a5468a3874832490114cf4fa0292ea