### PR TITLE
fix: stabilize header layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -86,6 +86,9 @@
   
   html {
     scroll-behavior: smooth;
+    /* Reserve space for scrollbar to prevent layout shift when dialogs or menus open */
+    overflow-y: scroll;
+    scrollbar-gutter: stable;
   }
 }
 


### PR DESCRIPTION
## Summary
- reserve vertical scrollbar space to prevent header shifting when PWA dialog or profile menu open

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: found existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a54ae8d11c8324ad819fa00eaa6d55