### PR TITLE
fix: prevent layout shift when menus or dialogs open

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -83,12 +83,19 @@
     background-color: hsl(var(--cream));
     color: hsl(var(--slate-gray));
   }
-  
+
   html {
     scroll-behavior: smooth;
     /* Reserve space for scrollbar to prevent layout shift when dialogs or menus open */
     overflow-y: scroll;
     scrollbar-gutter: stable;
+  }
+
+  /* Prevent Radix scroll-lock from shifting layout by adding body padding/margin */
+  body[data-scroll-locked] {
+    margin-right: 0 !important;
+    padding-right: 0 !important;
+    --removed-body-scroll-bar-size: 0 !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent Radix scroll lock from adding padding/margin that shifts layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 49 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a54d2604a48324a6dd40b28105fc40