### PR TITLE
fix(admin): update profile menu link

### DIFF
--- a/src/components/ProfileMenu.tsx
+++ b/src/components/ProfileMenu.tsx
@@ -79,11 +79,11 @@ const ProfileMenu = ({ onSignOut }: ProfileMenuProps) => {
         )}
         {userRole === 'Admin' && (
           <>
-            {/* Admins see RootedAI portal and their profile */}
+            {/* Admins see RootedAI admin link and their profile */}
             <DropdownMenuItem asChild>
-              <Link to="/rooted-ai" className="cursor-pointer">
+              <Link to="/admin" className="cursor-pointer">
                 <Building className="mr-2 h-4 w-4" />
-                <span>RootedAI Portal</span>
+                <span>RootedAI Admin</span>
               </Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>


### PR DESCRIPTION
## Summary
- rename admin-only profile menu item from RootedAI Portal to RootedAI Admin
- point the admin profile link to `/admin`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 45 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a656fb072c8324b0ee29e33901838a