### PR TITLE
Align Adoption Coaching widget with others

### DIFF
--- a/src/components/client-portal/CoachingCard.tsx
+++ b/src/components/client-portal/CoachingCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Button } from '@/components/ui/button';
 import EmptyState from './EmptyState';
 
 interface CoachingCardProps {
@@ -8,20 +7,11 @@ interface CoachingCardProps {
 
 const CoachingCard: React.FC<CoachingCardProps> = ({ nextSession }) => {
   if (!nextSession) {
-    return (
-      <EmptyState
-        message="Pick a time to continue your roadmap."
-        actionLabel="Book a 30-min session"
-        actionHref="#"
-      />
-    );
+    return <EmptyState message="Pick a time to continue your roadmap." />;
   }
 
   return (
-    <div className="space-y-2">
-      <p className="text-sm text-slate-gray">Next session: {nextSession}</p>
-      <Button className="bg-forest-green text-white">Book a 30-min session</Button>
-    </div>
+    <p className="text-sm text-slate-gray">Next session: {nextSession}</p>
   );
 };
 

--- a/src/components/client-portal/EmptyState.tsx
+++ b/src/components/client-portal/EmptyState.tsx
@@ -11,7 +11,7 @@ interface EmptyStateProps {
 const EmptyState: React.FC<EmptyStateProps> = ({ message, actionLabel, actionHref }) => {
   return (
     <div className="flex flex-col items-center text-center py-6">
-      <Leaf className="h-8 w-8 text-sage mb-4" />
+      <Leaf className="h-8 w-8 text-sage mb-4 shrink-0" />
       <p className="text-sm text-slate-gray mb-4">{message}</p>
       {actionLabel && actionHref && (
         <Button asChild className="bg-forest-green text-white">

--- a/src/pages/ClientPortal.tsx
+++ b/src/pages/ClientPortal.tsx
@@ -130,9 +130,14 @@ const ClientPortal: React.FC = () => {
             <CardHeader>
               <CardTitle className="text-forest-green">Adoption Coaching</CardTitle>
             </CardHeader>
-            <CardContent className="flex-1 flex items-center">
+            <CardContent className="flex-1">
               <CoachingCard nextSession={nextSession} />
             </CardContent>
+            <div className="px-6 pb-4">
+              <Button className="w-full bg-forest-green text-cream hover:bg-forest-green/90">
+                Book a 30-min session
+              </Button>
+            </div>
           </Card>
         </div>
 


### PR DESCRIPTION
## Summary
- Align Adoption Coaching card layout and button placement with other widgets
- Simplify CoachingCard content and ensure leaf icon sizing matches other widgets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 45 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a65e2f6b488324bed0ee755b0eb7ac