### PR TITLE
Fix client portal default company selection

### DIFF
--- a/src/pages/ClientPortal.tsx
+++ b/src/pages/ClientPortal.tsx
@@ -15,8 +15,16 @@ import { supabase } from '@/integrations/supabase/client';
 
 const ClientPortal: React.FC = () => {
   const { user, userRole, companies, loading } = useAuth();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const companyParam = searchParams.get('company');
+
+  // Default to the user's first company if no company is specified
+  useEffect(() => {
+    if (!companyParam && companies.length > 0) {
+      setSearchParams({ company: companies[0].slug });
+    }
+  }, [companyParam, companies, setSearchParams]);
+
   const company = companyParam
     ? companies.find(c => c.slug === companyParam)
     : companies[0];


### PR DESCRIPTION
## Summary
- Ensure client portal auto-selects the user's first company when no `company` query param is provided

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: 48 problems, 33 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b9baab48324bb55a2b04b04e4e2