### PR TITLE
Improve auth session stability

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -9,4 +9,11 @@ const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiO
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    multiTab: true
+  }
+});


### PR DESCRIPTION
## Summary
- restore Supabase sessions from local cache when `getSession` fails during initialization
- try to recover session on tab visibility instead of signing out immediately
- enable persistent, auto-refreshing Supabase auth sessions

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty in supabase functions)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afb849deb883249a7185e08e7c0337