### PR TITLE
feat: soften core values card animation

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -92,10 +92,10 @@ const About = () => {
             </h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
               {values.map((value, index) => (
-                <AnimatedSection 
-                  key={index} 
-                  animation="animate-elastic-in" 
-                  delay={300 + index * 100}
+                <AnimatedSection
+                  key={index}
+                  animation="animate-fade-in-up"
+                  delay={index * 100}
                 >
                   <Card className="card-energy border-sage/30 hover:border-forest-green/50 text-center group h-full">
                     <CardContent className="p-6">


### PR DESCRIPTION
## Summary
- soften "Our Core Values" cards by switching to a fade-up animation and reducing delay

## Testing
- `npm run lint` (fails: 52 problems (37 errors, 15 warnings))
- `npx eslint src/components/About.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68afbec662348324ae675b90941e602a