### PR TITLE
Improve PWA caching reliability for navigation and API requests

### DIFF
--- a/src/hooks/usePWAUpdate.tsx
+++ b/src/hooks/usePWAUpdate.tsx
@@ -15,7 +15,7 @@ export const usePWAUpdate = (): PWAUpdateHook => {
   const [hasUpdate, setHasUpdate] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [updateAvailable, setUpdateAvailable] = useState(false);
-  const [currentVersion, setCurrentVersion] = useState('1.2.0'); // Default from service worker
+  const [currentVersion, setCurrentVersion] = useState('1.4.0'); // Default from service worker
   const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(null);
   const [newWorker, setNewWorker] = useState<ServiceWorker | null>(null);
   const { toast } = useToast();


### PR DESCRIPTION
## Summary
- use network-first caching for navigation and API calls with offline fallbacks
- handle image caching errors and bump service worker version
- sync PWA update hook with new service worker version

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 53 problems in repo)*
- `npx eslint public/sw.js src/hooks/usePWAUpdate.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68afc3f9d758832480796c19926bbd90