### PR TITLE
Include full name metadata during invitation signup

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -300,6 +300,7 @@ const Auth = () => {
           password: password,
           options: {
             emailRedirectTo: redirectUrl,
+            data: { full_name: fullName },
           },
         });
 
@@ -308,7 +309,7 @@ const Auth = () => {
           // Fallback: try passwordless email OTP (often succeeds when signup hits a DB 500)
           const { error: otpError } = await supabase.auth.signInWithOtp({
             email: invitation.email,
-            options: { emailRedirectTo: redirectUrl },
+            options: { emailRedirectTo: redirectUrl, data: { full_name: fullName } },
           });
 
           if (otpError) {


### PR DESCRIPTION
## Summary
- send `full_name` as metadata when invited users sign up
- include `full_name` in OTP fallback to avoid DB errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 37 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1168668a48324b7ed54870c48a4d5