### PR TITLE
fix: improve PWA offline support and registration

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,6 +2,7 @@ const CACHE_VERSION = '1.3.0';
 const CACHE_NAME = `rooted-ai-v${CACHE_VERSION}`;
 const STATIC_CACHE = `${CACHE_NAME}-static`;
 const API_CACHE = `${CACHE_NAME}-api`;
+const OFFLINE_FALLBACK = '/';
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -10,6 +11,7 @@ self.addEventListener('install', (event) => {
       .then((cache) =>
         cache.addAll([
           '/',
+          '/index.html',
           '/manifest.json',
           '/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png',
         ])
@@ -59,6 +61,14 @@ self.addEventListener('fetch', (event) => {
   if (event.request.url.includes('/lovable-uploads/')) {
     const redirected = event.request.url.replace('/lovable-uploads/', '/Assets/');
     event.respondWith(fetch(redirected));
+    return;
+  }
+
+  // Network-first strategy for navigation requests with offline fallback
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(OFFLINE_FALLBACK))
+    );
     return;
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,3 +26,12 @@ if (splash) {
     splash.remove();
   }
 }
+
+// Register service worker in production for PWA capabilities
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/sw.js')
+      .catch((err) => console.error('Service worker registration failed:', err));
+  });
+}


### PR DESCRIPTION
## Summary
- ensure service worker caches index and provides offline navigation fallback
- register service worker in production for stable PWA sessions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 56 problems (40 errors, 16 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b669fde1008324a3d961486e123dbd