### PR TITLE
Add company dropdown for client invitations

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -957,7 +957,7 @@ const AdminDashboard: React.FC = () => {
           </DialogContent>
         </Dialog>
 
-        <ClientInvitationManager />
+        <ClientInvitationManager companies={allCompanies} />
         
         <PortalContentManager companies={allCompanies} currentAdmin={user?.email || ""} />
       </div>


### PR DESCRIPTION
## Summary
- expose company management UI on admin dashboard
- require selecting an existing company when inviting client users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, empty block statements, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7a7a973688324b1587f5db8cad8f1