### PR TITLE
Unify admin page header styling

### DIFF
--- a/src/components/admin/ClientInvitationManager.tsx
+++ b/src/components/admin/ClientInvitationManager.tsx
@@ -109,14 +109,15 @@ const ClientInvitationManager: React.FC<ClientInvitationManagerProps> = ({ onInv
       fetchInvitations();
       onInvitationSent?.();
 
-    } catch (error: any) {
+    } catch (error) {
       console.error('Failed to send invitation:', error);
       let description = 'Failed to send invitation';
-      
-      if (error?.message?.includes('rate limit')) {
+
+      const message = error instanceof Error ? error.message : '';
+      if (message.includes('rate limit')) {
         description = 'Rate limit exceeded. Please wait before sending more invitations.';
-      } else if (error?.message) {
-        description = error.message;
+      } else if (message) {
+        description = message;
       }
 
       toast({
@@ -186,19 +187,17 @@ const ClientInvitationManager: React.FC<ClientInvitationManagerProps> = ({ onInv
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
-        <div>
-          <CardTitle className="text-forest-green flex items-center gap-2">
-            <Mail className="h-5 w-5" />
-            Client Invitations
-          </CardTitle>
-          <p className="text-slate-gray text-sm">
-            Manage client invitations and portal access
-          </p>
-        </div>
+      <CardHeader className="space-y-4">
+        <CardTitle className="text-forest-green flex items-center gap-2">
+          <Mail className="h-5 w-5" />
+          Client Invitations
+        </CardTitle>
+        <p className="text-slate-gray text-sm">
+          Manage client invitations and portal access
+        </p>
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <DialogTrigger asChild>
-            <Button className="bg-forest-green hover:bg-forest-green/90">
+            <Button className="bg-forest-green hover:bg-forest-green/90 w-fit">
               <Plus className="h-4 w-4 mr-2" />
               Invite Client
             </Button>

--- a/src/components/admin/PortalContentManager.tsx
+++ b/src/components/admin/PortalContentManager.tsx
@@ -624,7 +624,7 @@ const PortalContentManager: React.FC<{ companies: CompanyOption[]; currentAdmin?
           .from('reports')
           .update({
             name: reportForm.name,
-            kpis: reportForm.kpis as any,
+            kpis: reportForm.kpis as unknown,
             period: reportForm.period || null,
             link: reportForm.link || null,
             notes: reportForm.notes || null
@@ -657,7 +657,7 @@ const PortalContentManager: React.FC<{ companies: CompanyOption[]; currentAdmin?
           .from('reports')
           .insert({
             name: reportForm.name,
-            kpis: reportForm.kpis as any,
+            kpis: reportForm.kpis as unknown,
             period: reportForm.period || null,
             link: reportForm.link || null,
             notes: reportForm.notes || null
@@ -1044,9 +1044,15 @@ const PortalContentManager: React.FC<{ companies: CompanyOption[]; currentAdmin?
     <div className="space-y-8">
       {/* Announcements */}
       <Card>
-        <CardHeader className="flex items-center justify-between">
-          <CardTitle>Announcements</CardTitle>
-          <Button size="sm" onClick={() => { resetForms(); setEditingAnnouncement(null); setAnnouncementOpen(true); }}>Add</Button>
+        <CardHeader className="space-y-4">
+          <CardTitle className="text-forest-green">Announcements</CardTitle>
+          <Button
+            size="sm"
+            onClick={() => { resetForms(); setEditingAnnouncement(null); setAnnouncementOpen(true); }}
+            className="bg-forest-green hover:bg-forest-green/90 mt-4 w-fit"
+          >
+            Add
+          </Button>
         </CardHeader>
         <CardContent>
           {announcements.length ? (
@@ -1059,9 +1065,15 @@ const PortalContentManager: React.FC<{ companies: CompanyOption[]; currentAdmin?
 
       {/* Resources */}
       <Card>
-        <CardHeader className="flex items-center justify-between">
-          <CardTitle>Training & Resources</CardTitle>
-          <Button size="sm" onClick={() => { resetForms(); setEditingResource(null); setResourceOpen(true); }}>Add</Button>
+        <CardHeader className="space-y-4">
+          <CardTitle className="text-forest-green">Training & Resources</CardTitle>
+          <Button
+            size="sm"
+            onClick={() => { resetForms(); setEditingResource(null); setResourceOpen(true); }}
+            className="bg-forest-green hover:bg-forest-green/90 mt-4 w-fit"
+          >
+            Add
+          </Button>
         </CardHeader>
         <CardContent>
           {resources.length ? (
@@ -1074,9 +1086,15 @@ const PortalContentManager: React.FC<{ companies: CompanyOption[]; currentAdmin?
 
       {/* Useful Links */}
       <Card>
-        <CardHeader className="flex items-center justify-between">
-          <CardTitle>Useful Links</CardTitle>
-          <Button size="sm" onClick={() => { resetForms(); setEditingLink(null); setLinkOpen(true); }}>Add</Button>
+        <CardHeader className="space-y-4">
+          <CardTitle className="text-forest-green">Useful Links</CardTitle>
+          <Button
+            size="sm"
+            onClick={() => { resetForms(); setEditingLink(null); setLinkOpen(true); }}
+            className="bg-forest-green hover:bg-forest-green/90 mt-4 w-fit"
+          >
+            Add
+          </Button>
         </CardHeader>
         <CardContent>
           {links.length ? (
@@ -1089,9 +1107,15 @@ const PortalContentManager: React.FC<{ companies: CompanyOption[]; currentAdmin?
 
       {/* Adoption Coaching */}
       <Card>
-        <CardHeader className="flex items-center justify-between">
-          <CardTitle>Adoption Coaching</CardTitle>
-          <Button size="sm" onClick={() => { resetForms(); setEditingCoaching(null); setCoachingOpen(true); }}>Add</Button>
+        <CardHeader className="space-y-4">
+          <CardTitle className="text-forest-green">Adoption Coaching</CardTitle>
+          <Button
+            size="sm"
+            onClick={() => { resetForms(); setEditingCoaching(null); setCoachingOpen(true); }}
+            className="bg-forest-green hover:bg-forest-green/90 mt-4 w-fit"
+          >
+            Add
+          </Button>
         </CardHeader>
         <CardContent>
           {coachings.length ? (
@@ -1104,9 +1128,15 @@ const PortalContentManager: React.FC<{ companies: CompanyOption[]; currentAdmin?
 
       {/* Reports & KPIs */}
       <Card>
-        <CardHeader className="flex items-center justify-between">
-          <CardTitle>Reports & KPIs</CardTitle>
-          <Button size="sm" onClick={() => { resetForms(); setEditingReport(null); setReportOpen(true); }}>Add</Button>
+        <CardHeader className="space-y-4">
+          <CardTitle className="text-forest-green">Reports & KPIs</CardTitle>
+          <Button
+            size="sm"
+            onClick={() => { resetForms(); setEditingReport(null); setReportOpen(true); }}
+            className="bg-forest-green hover:bg-forest-green/90 mt-4 w-fit"
+          >
+            Add
+          </Button>
         </CardHeader>
         <CardContent>
           {reports.length ? (
@@ -1119,9 +1149,15 @@ const PortalContentManager: React.FC<{ companies: CompanyOption[]; currentAdmin?
 
       {/* FAQs */}
       <Card>
-        <CardHeader className="flex items-center justify-between">
-          <CardTitle>FAQs</CardTitle>
-          <Button size="sm" onClick={() => { resetForms(); setEditingFaq(null); setFaqOpen(true); }}>Add</Button>
+        <CardHeader className="space-y-4">
+          <CardTitle className="text-forest-green">FAQs</CardTitle>
+          <Button
+            size="sm"
+            onClick={() => { resetForms(); setEditingFaq(null); setFaqOpen(true); }}
+            className="bg-forest-green hover:bg-forest-green/90 mt-4 w-fit"
+          >
+            Add
+          </Button>
         </CardHeader>
         <CardContent>
           {faqs.length ? (

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -601,17 +601,19 @@ const AdminDashboard: React.FC = () => {
 
         {/* Company Portals Section */}
         <Card>
-          <CardHeader className="flex items-center justify-between">
-            <div>
-              <CardTitle className="flex items-center gap-2">
-                <Building2 className="h-5 w-5" />
-                Company Portals
-              </CardTitle>
-              <CardDescription>
-                Access and manage all registered company portals and their user counts.
-              </CardDescription>
-            </div>
-            <Button size="sm" onClick={() => openCompanyDialog()}>
+          <CardHeader className="space-y-4">
+            <CardTitle className="flex items-center gap-2 text-forest-green">
+              <Building2 className="h-5 w-5" />
+              Company Portals
+            </CardTitle>
+            <CardDescription>
+              Access and manage all registered company portals and their user counts.
+            </CardDescription>
+            <Button
+              size="sm"
+              onClick={() => openCompanyDialog()}
+              className="bg-forest-green hover:bg-forest-green/90 mt-4 w-fit"
+            >
               <Plus className="h-4 w-4 mr-1" />
               Add Company
             </Button>
@@ -737,7 +739,7 @@ const AdminDashboard: React.FC = () => {
         {/* User Management Section */}
         <Card>
           <CardHeader>
-            <CardTitle className="flex items-center gap-2">
+            <CardTitle className="flex items-center gap-2 text-forest-green">
               <Users className="h-5 w-5" />
               User Management
             </CardTitle>
@@ -907,17 +909,19 @@ const AdminDashboard: React.FC = () => {
 
         {/* Newsletter Subscriptions Section */}
         <Card>
-          <CardHeader className="flex items-center justify-between">
-            <div>
-              <CardTitle className="flex items-center gap-2">
-                <MessageSquare className="h-5 w-5" />
-                Newsletter Subscriptions
-              </CardTitle>
-              <CardDescription>
-                Manage newsletter subscriptions and subscriber status.
-              </CardDescription>
-            </div>
-            <Button size="sm" onClick={openNewsletterDialog}>
+          <CardHeader className="space-y-4">
+            <CardTitle className="flex items-center gap-2 text-forest-green">
+              <MessageSquare className="h-5 w-5" />
+              Newsletter Subscriptions
+            </CardTitle>
+            <CardDescription>
+              Manage newsletter subscriptions and subscriber status.
+            </CardDescription>
+            <Button
+              size="sm"
+              onClick={openNewsletterDialog}
+              className="bg-forest-green hover:bg-forest-green/90 mt-4 w-fit"
+            >
               <Plus className="h-4 w-4 mr-1" />
               Add Subscriber
             </Button>


### PR DESCRIPTION
## Summary
- apply consistent forest-green styling to admin dashboard section headers and buttons
- vertically stack action buttons beneath their respective headers across admin components
- tighten typings in invitation and portal managers to satisfy lint rules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/pages/AdminDashboard.tsx src/components/admin/ClientInvitationManager.tsx src/components/admin/PortalContentManager.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b7aded246c8324a038ae0e82f1000c