### PR TITLE
feat: enhance client portal interactions

### DIFF
--- a/src/components/client-portal/AnnouncementCard.tsx
+++ b/src/components/client-portal/AnnouncementCard.tsx
@@ -1,23 +1,66 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 
 interface AnnouncementCardProps {
   title: string;
   date: string;
   status?: 'New' | 'Important';
+  summary?: string;
+  content?: string;
+  url?: string;
 }
 
-const AnnouncementCard: React.FC<AnnouncementCardProps> = ({ title, date, status }) => {
+const AnnouncementCard: React.FC<AnnouncementCardProps> = ({
+  title,
+  date,
+  status,
+  summary,
+  content,
+  url,
+}) => {
   return (
-    <div className="py-2 border-b last:border-b-0">
-      <div className="flex items-center justify-between mb-1">
-        <p className="text-sm font-medium text-slate-700 dark:text-slate-200">{title}</p>
-        {status && (
-          <Badge className="bg-forest-green/10 text-forest-green">{status}</Badge>
-        )}
-      </div>
-      <p className="text-xs text-slate-gray">{date}</p>
-    </div>
+    <Dialog>
+      <DialogTrigger asChild>
+        <div className="py-2 border-b last:border-b-0 cursor-pointer">
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-sm font-medium text-slate-700 dark:text-slate-200">{title}</p>
+            {status && (
+              <Badge className="bg-forest-green/10 text-forest-green">{status}</Badge>
+            )}
+          </div>
+          <p className="text-xs text-slate-gray">{date}</p>
+        </div>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <div className="mt-2 space-y-2">
+          {summary && <p className="text-sm text-slate-gray">{summary}</p>}
+          {content && (
+            <p className="text-sm text-slate-700 whitespace-pre-wrap">{content}</p>
+          )}
+          {url && (
+            <Button
+              asChild
+              className="mt-4 bg-forest-green text-cream hover:bg-forest-green/90"
+            >
+              <a href={url} target="_blank" rel="noopener noreferrer">
+                Open Link
+              </a>
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/src/components/client-portal/KPITile.tsx
+++ b/src/components/client-portal/KPITile.tsx
@@ -3,15 +3,29 @@ import React from 'react';
 interface KPITileProps {
   label: string;
   value: string;
+  target?: string;
 }
 
-const KPITile: React.FC<KPITileProps> = ({ label, value }) => {
+const KPITile: React.FC<KPITileProps> = ({ label, value, target }) => {
+  const valueNum = parseFloat(value);
+  const targetNum = target ? parseFloat(target) : NaN;
+  const progress =
+    !isNaN(valueNum) && !isNaN(targetNum) && targetNum > 0
+      ? Math.min(100, (valueNum / targetNum) * 100)
+      : 0;
+
   return (
     <div className="p-4 bg-white rounded-lg shadow-sm border border-sage/20">
       <div className="text-xs text-slate-gray mb-1">{label}</div>
-      <div className="text-xl font-bold text-forest-green">{value}</div>
+      <div className="text-xl font-bold text-forest-green">
+        {value}
+        {target ? `/${target}` : ''}
+      </div>
       <div className="mt-2 h-1.5 bg-sage/20 rounded-full overflow-hidden">
-        <div className="h-full bg-forest-green" style={{ width: '50%' }}></div>
+        <div
+          className="h-full bg-forest-green"
+          style={{ width: `${progress}%` }}
+        ></div>
       </div>
     </div>
   );

--- a/src/components/client-portal/ResourceCard.tsx
+++ b/src/components/client-portal/ResourceCard.tsx
@@ -12,6 +12,8 @@ const ResourceCard: React.FC<ResourceCardProps> = ({ title, type, href }) => {
   return (
     <a
       href={href}
+      target={href ? "_blank" : undefined}
+      rel={href ? "noopener noreferrer" : undefined}
       className="block p-3 rounded-lg border border-sage/20 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-forest-green"
     >
       <div className="flex items-center justify-between mb-2">

--- a/src/components/client-portal/UsefulLinkCard.tsx
+++ b/src/components/client-portal/UsefulLinkCard.tsx
@@ -10,6 +10,8 @@ const UsefulLinkCard: React.FC<UsefulLinkCardProps> = ({ title, url }) => {
   return (
     <a
       href={url}
+      target="_blank"
+      rel="noopener noreferrer"
       className="block p-3 rounded-lg border border-sage/20 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-forest-green"
     >
       <div className="flex items-center justify-between">

--- a/src/components/optimized/OptimizedClientPortal.tsx
+++ b/src/components/optimized/OptimizedClientPortal.tsx
@@ -21,11 +21,11 @@ const EmptyState = React.lazy(() => import('@/components/client-portal/EmptyStat
 const AiToolCard = React.lazy(() => import('@/components/client-portal/AiToolCard'));
 
 interface CompanyData {
-  announcements: Array<{ id: string; title: string; date: string; status?: 'New' | 'Important' }>;
+  announcements: Array<{ id: string; title: string; date: string; summary?: string; content?: string; url?: string; status?: 'New' | 'Important' }>;
   resources: Array<{ id: string; title: string; type: 'Guide' | 'Video' | 'Slide'; href?: string }>;
   usefulLinks: Array<{ id: string; title: string; url: string }>;
   nextSession?: string;
-  kpis: Array<{ name: string; value: string }>;
+  kpis: Array<{ name: string; value: string; target?: string }>;
   faqs: Array<{ id: string; question: string; answer: string }>;
   aiTools: Array<{ id: string; ai_tool: string; url?: string; comments?: string }>;
 }
@@ -110,7 +110,7 @@ const OptimizedClientPortal: React.FC = () => {
       ] = await Promise.allSettled([
         supabase
           .from('announcements')
-          .select('id, title, created_at, announcement_companies!inner(company_id)')
+          .select('id, title, summary, content, url, created_at, announcement_companies!inner(company_id)')
           .eq('announcement_companies.company_id', companyId)
           .order('created_at', { ascending: false })
           .limit(5),
@@ -160,6 +160,9 @@ const OptimizedClientPortal: React.FC = () => {
             id: a.id,
             title: a.title || '',
             date: a.created_at ? new Date(a.created_at).toLocaleDateString() : '',
+            summary: a.summary || '',
+            content: a.content || '',
+            url: a.url || '',
           }))
         : [];
 
@@ -190,7 +193,7 @@ const OptimizedClientPortal: React.FC = () => {
         reportsResult.value.data && 
         reportsResult.value.data[0] && 
         Array.isArray(reportsResult.value.data[0].kpis)
-        ? reportsResult.value.data[0].kpis as Array<{ name: string; value: string }>
+        ? reportsResult.value.data[0].kpis as Array<{ name: string; value: string; target?: string }>
         : [];
 
       const faqs = faqsResult.status === 'fulfilled' && faqsResult.value.data
@@ -335,7 +338,15 @@ const OptimizedClientPortal: React.FC = () => {
                 <CardContent className="flex-1">
                   {data.announcements.length ? (
                     data.announcements.map(a => (
-                      <AnnouncementCard key={a.id} title={a.title} date={a.date} status={a.status} />
+                      <AnnouncementCard
+                        key={a.id}
+                        title={a.title}
+                        date={a.date}
+                        status={a.status}
+                        summary={a.summary}
+                        content={a.content}
+                        url={a.url}
+                      />
                     ))
                   ) : (
                     <EmptyState message="No announcements yet." />
@@ -417,7 +428,7 @@ const OptimizedClientPortal: React.FC = () => {
                 <CardContent className="grid grid-cols-2 gap-4">
                   {data.kpis.length ? (
                     data.kpis.map((kpi, idx) => (
-                      <KPITile key={idx} label={kpi.name} value={kpi.value} />
+                      <KPITile key={idx} label={kpi.name} value={kpi.value} target={kpi.target} />
                     ))
                   ) : (
                     <EmptyState message="No reports yet." />

--- a/src/hooks/usePrefetch.tsx
+++ b/src/hooks/usePrefetch.tsx
@@ -56,7 +56,7 @@ export function usePrefetch({
       const [announcements, resources, usefulLinks, coaching, reports, faqs, aiTools] = await Promise.allSettled([
         supabase
           .from('announcements')
-          .select('id, title, created_at, announcement_companies!inner(company_id)')
+          .select('id, title, summary, content, url, created_at, announcement_companies!inner(company_id)')
           .eq('announcement_companies.company_id', companyId)
           .order('created_at', { ascending: false })
           .limit(5),

--- a/src/pages/ClientPortal.tsx
+++ b/src/pages/ClientPortal.tsx
@@ -55,11 +55,11 @@ const ClientPortal: React.FC = () => {
   const activeCompany = company || resolvedCompany;
   const companySlug = activeCompany?.slug;
 
-  const [announcements, setAnnouncements] = useState<Array<{ id: string; title: string; date: string; status?: 'New' | 'Important'; }>>([]);
+  const [announcements, setAnnouncements] = useState<Array<{ id: string; title: string; date: string; summary?: string; content?: string; url?: string; status?: 'New' | 'Important'; }>>([]);
   const [resources, setResources] = useState<Array<{ id: string; title: string; type: 'Guide' | 'Video' | 'Slide'; href?: string }>>([]);
   const [usefulLinks, setUsefulLinks] = useState<Array<{ id: string; title: string; url: string }>>([]);
   const [nextSession, setNextSession] = useState<string | undefined>();
-  const [kpis, setKpis] = useState<Array<{ name: string; value: string }>>([]);
+  const [kpis, setKpis] = useState<Array<{ name: string; value: string; target?: string }>>([]);
   const [faqs, setFaqs] = useState<Array<{ id: string; question: string; answer: string }>>([]);
   const [aiTools, setAiTools] = useState<Array<{ id: string; ai_tool: string; url?: string; comments?: string }>>([]);
 
@@ -74,7 +74,7 @@ useEffect(() => {
         // Announcements
         const { data: annData, error: annError } = await supabase
           .from('announcements')
-          .select('id, title, created_at, announcement_companies!inner(company_id)')
+          .select('id, title, summary, content, url, created_at, announcement_companies!inner(company_id)')
           .eq('announcement_companies.company_id', companyId)
           .order('created_at', { ascending: false });
         
@@ -86,6 +86,9 @@ useEffect(() => {
               id: a.id,
               title: a.title || '',
               date: a.created_at ? new Date(a.created_at).toLocaleDateString() : '',
+              summary: a.summary || '',
+              content: a.content || '',
+              url: a.url || '',
             }))
           );
         }
@@ -156,7 +159,7 @@ useEffect(() => {
         if (!reportError && reportData && reportData[0]) {
           const kpiData = reportData[0].kpis;
           if (Array.isArray(kpiData)) {
-            setKpis(kpiData as Array<{ name: string; value: string }>);
+            setKpis(kpiData as Array<{ name: string; value: string; target?: string }>);
           } else {
             setKpis([]);
           }
@@ -260,7 +263,15 @@ useEffect(() => {
             <CardContent className="flex-1">
               {announcements.length ? (
                 announcements.map(a => (
-                  <AnnouncementCard key={a.id} title={a.title} date={a.date} status={a.status} />
+                  <AnnouncementCard
+                    key={a.id}
+                    title={a.title}
+                    date={a.date}
+                    status={a.status}
+                    summary={a.summary}
+                    content={a.content}
+                    url={a.url}
+                  />
                 ))
               ) : (
                 <EmptyState message="No announcements yet." />
@@ -334,7 +345,7 @@ useEffect(() => {
             <CardContent className="grid grid-cols-2 gap-4">
               {kpis.length ? (
                 kpis.map((kpi, idx) => (
-                  <KPITile key={idx} label={kpi.name} value={kpi.value} />
+                  <KPITile key={idx} label={kpi.name} value={kpi.value} target={kpi.target} />
                 ))
               ) : (
                 <EmptyState message="No reports yet." />


### PR DESCRIPTION
## Summary
- display announcements in a modal with full details and link
- open resource and useful link URLs in new tabs
- visualize KPI progress against goals with dynamic progress bar

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 131 problems in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba5d0115b88324ba4aa0b26c8ef6de