### PR TITLE
Update admin user management title and hide footer branding

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,11 @@ import { useAuth } from '@/hooks/useAuth';
 import { RefreshCw, User } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
-const Footer = () => {
+interface FooterProps {
+  hideBrandSection?: boolean;
+}
+
+const Footer: React.FC<FooterProps> = ({ hideBrandSection = false }) => {
   const currentYear = new Date().getFullYear();
   const [showUpdateDialog, setShowUpdateDialog] = useState(false);
   const { user } = useAuth();
@@ -27,28 +31,30 @@ const Footer = () => {
   return (
     <footer className="bg-slate-gray dark:bg-slate-900 text-cream py-12">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 gap-8">
-          {/* Brand Section */}
-          <div>
-            <div className="flex items-center space-x-2 mb-4">
-              <img 
-                src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
-                alt="RootedAI Logo" 
-                className="w-8 h-8" 
-              />
-              <span className="text-2xl font-bold text-cream dark:text-white">RootedAI</span>
+        {!hideBrandSection && (
+          <div className="grid grid-cols-1 gap-8">
+            {/* Brand Section */}
+            <div>
+              <div className="flex items-center space-x-2 mb-4">
+                <img
+                  src="/Assets/18d38cb4-658a-43aa-8b10-fa6dbd50eae7.png"
+                  alt="RootedAI Logo"
+                  className="w-8 h-8"
+                />
+                <span className="text-2xl font-bold text-cream dark:text-white">RootedAI</span>
+              </div>
+              <p className="text-sage dark:text-white mb-4 max-w-md">
+                Helping Kansas City small businesses grow smarter with AI solutions built on Microsoft tools.
+                Local expertise, trusted partnerships, sustainable growth.
+              </p>
+              <p className="text-lg font-semibold text-sage dark:text-white">
+                Grow Smarter. Stay Rooted.
+              </p>
             </div>
-            <p className="text-sage dark:text-white mb-4 max-w-md">
-              Helping Kansas City small businesses grow smarter with AI solutions built on Microsoft tools. 
-              Local expertise, trusted partnerships, sustainable growth.
-            </p>
-            <p className="text-lg font-semibold text-sage dark:text-white">
-              Grow Smarter. Stay Rooted.
-            </p>
-          </div>
 
-          {/* Removed AI Joke section */}
-        </div>
+            {/* Removed AI Joke section */}
+          </div>
+        )}
 
         {/* Bottom Section */}
         <div className="border-t border-sage/20 mt-8 pt-8 flex flex-col md:flex-row justify-between items-center">

--- a/src/components/admin/UnifiedUserManager.tsx
+++ b/src/components/admin/UnifiedUserManager.tsx
@@ -674,7 +674,7 @@ const UnifiedUserManager: React.FC<UnifiedUserManagerProps> = ({ companies }) =>
           <div>
             <CardTitle className="text-forest-green flex items-center gap-2">
               <Users className="h-5 w-5" />
-              Unified User Management
+              Manage Users
             </CardTitle>
             <p className="text-slate-gray text-sm">
               Manage all users, invitations, and newsletter subscriptions in one place

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -264,7 +264,7 @@ const AdminDashboard: React.FC = () => {
           onManageUsers={openCompanyUsersDialog}
         />
 
-        {/* Unified User Management */}
+        {/* Manage Users */}
         <UnifiedUserManager companies={allCompanies.map(c => ({ id: c.id, name: c.name, slug: c.slug }))} />
 
         {/* Portal Content Management */}
@@ -315,7 +315,7 @@ const AdminDashboard: React.FC = () => {
         </Dialog>
 
       </div>
-      <Footer />
+      <Footer hideBrandSection />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- rename the admin user manager card heading to “Manage Users”
- allow the footer to hide its brand section when desired
- suppress the footer branding on the admin dashboard to match the requested layout

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68caa3ebdebc83248a863e6a4e153130