### PR TITLE
Replace logo loader with plant growth animation

### DIFF
--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-const logoSrc = '/Assets/22badab3-8f25-475f-92d7-167cbc732868.png';
-
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg' | 'xl';
   text?: string;
@@ -23,77 +21,23 @@ interface LoadingIconProps {
 
 export const LoadingIcon: React.FC<LoadingIconProps> = ({ size = 'md', className = '' }) => {
   return (
-    <div className={`relative mx-auto flex items-center justify-center ${sizeClasses[size]} ${className}`}>
-      <img
-        src={logoSrc}
-        alt="RootedAI logo"
-        className="w-full h-full object-contain"
-      />
-      <svg
-        className="absolute inset-0 w-full h-full"
-        viewBox="0 0 100 100"
-        fill="none"
-      >
-        <g stroke="#16a34a" strokeWidth="4" strokeLinecap="round">
-          <path d="M50 60 L50 90" strokeDasharray="30" strokeDashoffset="30">
-            <animate
-              attributeName="stroke-dashoffset"
-              values="30;0;30"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </path>
-          <path d="M50 75 L40 90" strokeDasharray="22" strokeDashoffset="22">
-            <animate
-              attributeName="stroke-dashoffset"
-              values="22;0;22"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </path>
-          <path d="M50 75 L60 90" strokeDasharray="22" strokeDashoffset="22">
-            <animate
-              attributeName="stroke-dashoffset"
-              values="22;0;22"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </path>
-          {/* Additional root outlines */}
-          <path d="M50 65 L45 80" strokeDasharray="16" strokeDashoffset="16">
-            <animate
-              attributeName="stroke-dashoffset"
-              values="16;0;16"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </path>
-          <path d="M50 65 L55 80" strokeDasharray="16" strokeDashoffset="16">
-            <animate
-              attributeName="stroke-dashoffset"
-              values="16;0;16"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </path>
-          <path d="M50 80 L43 90" strokeDasharray="12" strokeDashoffset="12">
-            <animate
-              attributeName="stroke-dashoffset"
-              values="12;0;12"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </path>
-          <path d="M50 80 L57 90" strokeDasharray="12" strokeDashoffset="12">
-            <animate
-              attributeName="stroke-dashoffset"
-              values="12;0;12"
-              dur="2s"
-              repeatCount="indefinite"
-            />
-          </path>
-        </g>
-      </svg>
+    <div
+      className={`plant-loader mx-auto ${sizeClasses[size]} ${className}`}
+      aria-hidden="true"
+    >
+      <div className="plant-loader__cycle" />
+      <div className="plant-loader__soil" />
+      <div className="plant-loader__seed" />
+      <div className="plant-loader__sprout">
+        <span className="plant-loader__stem" />
+        <span className="plant-loader__leaf plant-loader__leaf--left" />
+        <span className="plant-loader__leaf plant-loader__leaf--right" />
+      </div>
+      <div className="plant-loader__roots">
+        <span className="plant-loader__root plant-loader__root--left" />
+        <span className="plant-loader__root plant-loader__root--center" />
+        <span className="plant-loader__root plant-loader__root--right" />
+      </div>
     </div>
   );
 };
@@ -103,8 +47,15 @@ export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   text,
   className = ''
 }) => {
+  const accessibleLabel = text ?? 'Loading';
+
   return (
-    <div className={`flex flex-col items-center justify-center space-y-2 ${className}`}>
+    <div
+      className={`flex flex-col items-center justify-center space-y-2 ${className}`}
+      role="status"
+      aria-label={accessibleLabel}
+      aria-live="polite"
+    >
       <LoadingIcon size={size} />
       {text && (
         <p className="text-sm text-muted-foreground animate-pulse">{text}</p>

--- a/src/index.css
+++ b/src/index.css
@@ -512,6 +512,315 @@
   }
 }
 
+@layer components {
+  .plant-loader {
+    @apply relative flex items-center justify-center;
+    --plant-duration: 2800ms;
+    --plant-color: hsl(var(--forest-green));
+    --plant-soft: hsl(var(--forest-green) / 0.7);
+    --plant-highlight: hsl(var(--forest-green) / 0.85);
+    --root-color: hsl(var(--earth-brown));
+    --root-soft: hsl(var(--earth-brown) / 0.75);
+  }
+
+  .plant-loader__cycle {
+    position: absolute;
+    inset: 10%;
+    border-radius: 9999px;
+    border: 2px solid hsl(var(--forest-green) / 0.2);
+    border-top-color: var(--plant-highlight);
+    opacity: 0.7;
+    filter: drop-shadow(0 0 6px hsl(var(--forest-green) / 0.25));
+    animation: plant-loader-cycle var(--plant-duration) ease-in-out infinite;
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  .plant-loader__soil {
+    position: absolute;
+    bottom: 18%;
+    width: 80%;
+    height: 20%;
+    background: linear-gradient(180deg, var(--root-soft), var(--root-color));
+    border-radius: 9999px;
+    opacity: 0.95;
+    filter: drop-shadow(0 6px 8px hsl(var(--earth-brown) / 0.18));
+    animation: plant-loader-soil var(--plant-duration) ease-in-out infinite;
+    z-index: 2;
+    pointer-events: none;
+  }
+
+  .plant-loader__seed {
+    position: absolute;
+    bottom: 26%;
+    width: 18%;
+    height: 18%;
+    border-radius: 50% 50% 45% 45%;
+    background: radial-gradient(circle at 35% 30%, hsl(var(--earth-brown) / 0.95), var(--root-color));
+    transform-origin: center bottom;
+    animation: plant-loader-seed var(--plant-duration) ease-in-out infinite;
+    z-index: 3;
+    pointer-events: none;
+  }
+
+  .plant-loader__sprout {
+    position: absolute;
+    bottom: 24%;
+    width: 50%;
+    height: 58%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    z-index: 4;
+    pointer-events: none;
+  }
+
+  .plant-loader__stem {
+    position: absolute;
+    bottom: 0;
+    width: 16%;
+    height: 100%;
+    border-radius: 9999px;
+    background: linear-gradient(180deg, var(--plant-soft), var(--plant-color));
+    transform-origin: bottom center;
+    transform: scaleY(0);
+    animation: plant-loader-stem var(--plant-duration) ease-in-out infinite;
+    box-shadow: 0 0 4px hsl(var(--forest-green) / 0.2);
+    pointer-events: none;
+  }
+
+  .plant-loader__leaf {
+    --leaf-rotation: 0deg;
+    position: absolute;
+    bottom: 55%;
+    width: 48%;
+    height: 42%;
+    border-radius: 100% 0 100% 0;
+    background: radial-gradient(circle at 30% 30%, var(--plant-highlight), var(--plant-soft));
+    opacity: 0;
+    transform-origin: bottom center;
+    transform: rotate(var(--leaf-rotation)) scale(0);
+    animation: plant-loader-leaf var(--plant-duration) ease-in-out infinite;
+    box-shadow: 0 4px 6px hsl(var(--forest-green) / 0.12);
+    pointer-events: none;
+  }
+
+  .plant-loader__leaf--left {
+    left: -8%;
+    --leaf-rotation: -32deg;
+  }
+
+  .plant-loader__leaf--right {
+    right: -8%;
+    --leaf-rotation: 32deg;
+  }
+
+  .plant-loader__roots {
+    position: absolute;
+    bottom: 4%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 72%;
+    height: 34%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    z-index: 1;
+    pointer-events: none;
+  }
+
+  .plant-loader__root {
+    position: relative;
+    width: 16%;
+    height: 100%;
+    border-radius: 9999px;
+    background: linear-gradient(180deg, var(--root-soft), var(--root-color));
+    opacity: 0;
+    --rotation: 0deg;
+    --branch-rotation: 0deg;
+    transform-origin: top center;
+    transform: rotate(var(--rotation)) scaleY(0);
+    animation: plant-loader-root var(--plant-duration) ease-in-out infinite;
+    pointer-events: none;
+  }
+
+  .plant-loader__root::after {
+    content: '';
+    position: absolute;
+    top: 55%;
+    left: 50%;
+    width: 80%;
+    height: 28%;
+    border-radius: 9999px;
+    background: linear-gradient(180deg, var(--root-soft), var(--root-color));
+    transform-origin: left top;
+    opacity: 0;
+    transform: rotate(var(--branch-rotation)) scaleX(0);
+    animation: plant-loader-root-branch var(--plant-duration) ease-in-out infinite;
+    pointer-events: none;
+  }
+
+  .plant-loader__root--left {
+    --rotation: -18deg;
+    --branch-rotation: 32deg;
+  }
+
+  .plant-loader__root--center {
+    --rotation: 0deg;
+    --branch-rotation: 0deg;
+  }
+
+  .plant-loader__root--right {
+    --rotation: 18deg;
+    --branch-rotation: -32deg;
+  }
+}
+
+@keyframes plant-loader-cycle {
+  0% {
+    transform: rotate(0deg) scale(0.85);
+    opacity: 0.45;
+  }
+
+  40% {
+    opacity: 0.85;
+  }
+
+  100% {
+    transform: rotate(360deg) scale(1);
+    opacity: 0.45;
+  }
+}
+
+@keyframes plant-loader-soil {
+  0%,
+  100% {
+    transform: translateY(0) scaleX(0.92);
+  }
+
+  35% {
+    transform: translateY(0) scaleX(1);
+  }
+
+  70% {
+    transform: translateY(4%) scaleX(0.94);
+  }
+}
+
+@keyframes plant-loader-seed {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(0.85);
+  }
+
+  30% {
+    opacity: 1;
+    transform: translateY(-18%) scale(1);
+  }
+
+  45% {
+    opacity: 0;
+    transform: translateY(-28%) scale(0.9);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(0) scale(0.85);
+  }
+}
+
+@keyframes plant-loader-stem {
+  0%,
+  25% {
+    transform: scaleY(0);
+  }
+
+  45% {
+    transform: scaleY(1);
+  }
+
+  70% {
+    transform: scaleY(0.98);
+  }
+
+  85% {
+    transform: scaleY(0.95);
+  }
+
+  100% {
+    transform: scaleY(0);
+  }
+}
+
+@keyframes plant-loader-leaf {
+  0%,
+  45% {
+    opacity: 0;
+    transform: rotate(var(--leaf-rotation)) scale(0);
+  }
+
+  60% {
+    opacity: 1;
+    transform: rotate(var(--leaf-rotation)) scale(1);
+  }
+
+  75% {
+    opacity: 1;
+    transform: rotate(var(--leaf-rotation)) scale(0.96);
+  }
+
+  100% {
+    opacity: 0;
+    transform: rotate(var(--leaf-rotation)) scale(0);
+  }
+}
+
+@keyframes plant-loader-root {
+  0%,
+  55% {
+    opacity: 0;
+    transform: rotate(var(--rotation)) scaleY(0);
+  }
+
+  70% {
+    opacity: 1;
+    transform: rotate(var(--rotation)) scaleY(1);
+  }
+
+  85% {
+    opacity: 1;
+    transform: rotate(var(--rotation)) scaleY(0.95);
+  }
+
+  100% {
+    opacity: 0;
+    transform: rotate(var(--rotation)) scaleY(0);
+  }
+}
+
+@keyframes plant-loader-root-branch {
+  0%,
+  65% {
+    opacity: 0;
+    transform: rotate(var(--branch-rotation)) scaleX(0);
+  }
+
+  78% {
+    opacity: 0.9;
+    transform: rotate(var(--branch-rotation)) scaleX(1);
+  }
+
+  90% {
+    opacity: 0.9;
+    transform: rotate(var(--branch-rotation)) scaleX(0.92);
+  }
+
+  100% {
+    opacity: 0;
+    transform: rotate(var(--branch-rotation)) scaleX(0);
+  }
+}
+
 @keyframes fadeInUp {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary
- replace the legacy RootedAI logo spinner with a CSS-driven plant growth loader
- layer in bespoke animations for seed, stem, leaves, roots, and a circular progress accent to echo the brand
- improve accessibility by exposing the loading message via a polite status region

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' because project dependencies cannot be installed due to a date-fns/react-day-picker peer conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68caa4f13fb483249015e0f18e744ce8