### PR TITLE
Make newsletter subscription card header match dashboard palette

### DIFF
--- a/src/components/client-portal/NewsletterSubscriptionCard.tsx
+++ b/src/components/client-portal/NewsletterSubscriptionCard.tsx
@@ -52,8 +52,8 @@ export const NewsletterSubscriptionCard = ({ companyId }: NewsletterSubscription
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Mail className="h-5 w-5" />
+        <CardTitle className="flex items-center gap-2 text-forest-green">
+          <Mail className="h-5 w-5 text-forest-green" />
           Newsletter Subscription
         </CardTitle>
         <CardDescription>


### PR DESCRIPTION
## Summary
- update the newsletter subscription card header to use the dashboard's forest green text color
- color the mail icon green to match the surrounding title styling

## Testing
- npm run lint *(fails: missing @eslint/js dependency in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cab28728ec8324ba8bec0ea71834ad