### PR TITLE
Move newsletter analytics card into main dashboard column

### DIFF
--- a/src/pages/ClientPortal.tsx
+++ b/src/pages/ClientPortal.tsx
@@ -456,7 +456,7 @@ const ClientPortal: React.FC = () => {
                         <div key={resource.id} className="animate-elastic-in" style={{ animationDelay: `${index * 0.1}s` }}>
                           <Suspense fallback={<Skeleton className="h-32 w-full" />}>
                             <div className="card-energy">
-                              <ResourceCard 
+                              <ResourceCard
                                 title={resource.title}
                                 type={resource.category || 'Guide'}
                                 href={resource.link}
@@ -477,6 +477,13 @@ const ClientPortal: React.FC = () => {
                         </Card>
                       </div>
                     )}
+                  </div>
+                )}
+
+                {/* Admin Newsletter Analytics */}
+                {(isAdmin || currentCompany?.isAdmin) && currentCompany?.id && (
+                  <div className="animate-slide-up-delayed">
+                    <AdminNewsletterStats companyId={currentCompany.id} />
                   </div>
                 )}
               </div>
@@ -576,13 +583,6 @@ const ClientPortal: React.FC = () => {
                 <div className="animate-slide-left-delayed">
                   <NewsletterSubscriptionCard companyId={currentCompany?.id} />
                 </div>
-
-                {/* Admin Newsletter Analytics */}
-                {(isAdmin || currentCompany?.isAdmin) && currentCompany?.id && (
-                  <div className="animate-slide-left-delayed">
-                    <AdminNewsletterStats companyId={currentCompany.id} />
-                  </div>
-                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- move the admin Newsletter Analytics card into the main dashboard column on the client portal
- ensure the analytics card displays beneath the Resource Library so it appears as a wide panel in the center content area

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2ce03c5c8324b63c64bf8b494d1b