### PR TITLE
Fix company admin scoped invitations

### DIFF
--- a/src/components/admin/UserInvitationManager.tsx
+++ b/src/components/admin/UserInvitationManager.tsx
@@ -17,6 +17,7 @@ interface Invitation {
   email: string;
   full_name: string;
   client_name: string | null;
+  company_id?: string | null;
   role: string;
   status: string;
   created_at: string;
@@ -118,7 +119,8 @@ const UserInvitationManager: React.FC<UserInvitationManagerProps> = ({ onInvitat
           email: formData.email,
           full_name: formData.full_name,
           role: formData.role,
-          client_name: clientName
+          client_name: clientName,
+          company_id: formData.companyId || undefined
         },
         headers: {
           Authorization: `Bearer ${session.access_token}`,
@@ -195,8 +197,8 @@ const UserInvitationManager: React.FC<UserInvitationManagerProps> = ({ onInvitat
 
   const handleEdit = (invitation: Invitation) => {
     setEditingInvitation(invitation);
-    let companyId = '';
-    if (invitation.role === 'Client' && invitation.client_name) {
+    let companyId = invitation.company_id || '';
+    if (!companyId && invitation.role === 'Client' && invitation.client_name) {
       const company = companies.find(c => c.name === invitation.client_name);
       if (company) {
         companyId = company.id;
@@ -233,6 +235,7 @@ const UserInvitationManager: React.FC<UserInvitationManagerProps> = ({ onInvitat
           full_name: editFormData.full_name,
           role: editFormData.role,
           client_name: clientName,
+          company_id: editFormData.companyId || null,
         })
         .eq('id', editingInvitation.id);
 


### PR DESCRIPTION
## Summary
- ensure the admin invitation manager includes the scoped company when creating or editing invites so memberships stay aligned
- update unified user management edits to persist invitation company assignments and keep client names in sync
- harden the send-invitation edge function to resolve company context, authorize company admins, and always persist the correct company id

## Testing
- npm run lint *(fails: existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7d724a8c8324bcf42fc4ecc6328f