### PR TITLE
Make user analytics tabs vertically stacked

### DIFF
--- a/src/components/client-portal/UserAnalyticsCard.tsx
+++ b/src/components/client-portal/UserAnalyticsCard.tsx
@@ -191,10 +191,10 @@ export const UserAnalyticsCard = ({ companyId }: UserAnalyticsCardProps) => {
       </CardHeader>
       <CardContent>
         <Tabs defaultValue={isCompanyAdmin ? "analytics" : "subscription"} className="w-full">
-          <TabsList className="grid w-full grid-cols-2 gap-2 bg-forest-green/5 p-1 rounded-lg">
+          <TabsList className="flex w-full flex-col gap-2 rounded-lg bg-forest-green/5 p-1">
             <TabsTrigger
               value="subscription"
-              className="flex items-center gap-2 text-sm text-forest-green data-[state=active]:bg-forest-green data-[state=active]:text-white data-[state=active]:shadow-sm"
+              className="flex w-full items-center justify-start gap-2 text-sm text-forest-green data-[state=active]:bg-forest-green data-[state=active]:text-white data-[state=active]:shadow-sm"
             >
               <Mail className="h-4 w-4" />
               My Subscription
@@ -202,7 +202,7 @@ export const UserAnalyticsCard = ({ companyId }: UserAnalyticsCardProps) => {
             <TabsTrigger
               value="analytics"
               disabled={!isCompanyAdmin}
-              className="flex items-center gap-2 text-sm text-forest-green data-[state=active]:bg-forest-green data-[state=active]:text-white data-[state=active]:shadow-sm disabled:text-muted-foreground"
+              className="flex w-full items-center justify-start gap-2 text-sm text-forest-green data-[state=active]:bg-forest-green data-[state=active]:text-white data-[state=active]:shadow-sm disabled:text-muted-foreground"
             >
               <TrendingUp className="h-4 w-4" />
               Company Analytics


### PR DESCRIPTION
## Summary
- update the User Analytics tab list styling so the subscription and analytics triggers stack vertically at full width
- ensure the triggers align their contents to the left for a consistent button-like layout across screen sizes

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfb00e9088324bfeea70ae6d47cf7