### PR TITLE
Make AI toolkit cards fully clickable

### DIFF
--- a/src/components/client-portal/AiToolCard.tsx
+++ b/src/components/client-portal/AiToolCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Button } from '@/components/ui/button';
 import { Bot, ExternalLink } from 'lucide-react';
 
 interface AiToolCardProps {
@@ -9,35 +8,35 @@ interface AiToolCardProps {
 }
 
 const AiToolCard: React.FC<AiToolCardProps> = ({ title, url, comments }) => {
-  const handleClick = () => {
-    if (url) {
-      window.open(url, '_blank', 'noopener,noreferrer');
-    }
-  };
-
-  return (
+  const content = (
     <div className="p-3 border border-sage/20 dark:border-sage/30 rounded-lg hover:bg-sage/5 dark:hover:bg-sage/10 transition-colors">
       <div className="flex items-start justify-between mb-2">
         <div className="flex items-center gap-2">
           <Bot className="h-4 w-4 text-forest-green dark:text-sage" />
           <span className="text-sm font-medium text-forest-green dark:text-sage">{title}</span>
         </div>
-        {url && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 w-6 p-0"
-            onClick={handleClick}
-          >
-            <ExternalLink className="h-3 w-3" />
-          </Button>
-        )}
+        {url && <ExternalLink className="h-3 w-3 text-slate-gray dark:text-slate-300" />}
       </div>
       {comments && (
         <p className="text-xs text-slate-gray dark:text-slate-300">{comments}</p>
       )}
     </div>
   );
+
+  if (url) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest-green/40 rounded-lg"
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return content;
 };
 
 export default AiToolCard;


### PR DESCRIPTION
## Summary
- wrap AI Toolkit cards in anchor elements when a URL is provided so the entire card opens in a new tab
- retain the external link visual indicator without relying on a button control

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68cce34576b08324b1e963d2d95db644