### PR TITLE
feat: improve notification read controls

### DIFF
--- a/src/components/notifications/NotificationCenter.tsx
+++ b/src/components/notifications/NotificationCenter.tsx
@@ -7,13 +7,15 @@ import { useToast } from '@/hooks/use-toast';
 
 export const NotificationCenter: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const { 
-    notifications, 
-    unreadCount, 
-    loading, 
-    markAsRead, 
+  const {
+    notifications,
+    unreadCount,
+    loading,
+    markAsRead,
     markAllAsRead,
-    error 
+    markAsUnread,
+    markAllAsUnread,
+    error
   } = useNotifications();
   const { toast } = useToast();
 
@@ -49,16 +51,64 @@ export const NotificationCenter: React.FC = () => {
 
   const handleMarkAllAsRead = async () => {
     try {
+      const unreadBefore = unreadCount;
       await markAllAsRead();
       toast({
         title: "All notifications marked as read",
-        description: `${unreadCount} notifications updated`,
+        description: `${unreadBefore} notifications updated`,
       });
     } catch (error) {
       console.error('Error marking all as read:', error);
       toast({
         title: "Error",
         description: "Failed to mark notifications as read",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleMarkAllAsUnread = async () => {
+    try {
+      const readCount = notifications.filter(notification => notification.is_read).length;
+      if (readCount === 0) {
+        return;
+      }
+
+      await markAllAsUnread();
+      toast({
+        title: "Notifications moved to unread",
+        description: `${readCount} notifications updated`,
+      });
+    } catch (error) {
+      console.error('Error marking all as unread:', error);
+      toast({
+        title: "Error",
+        description: "Failed to mark notifications as unread",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleToggleReadState = async (notification: Notification) => {
+    try {
+      if (notification.is_read) {
+        await markAsUnread(notification.id);
+        toast({
+          title: "Marked as unread",
+          description: notification.title,
+        });
+      } else {
+        await markAsRead(notification.id);
+        toast({
+          title: "Marked as read",
+          description: notification.title,
+        });
+      }
+    } catch (error) {
+      console.error('Error updating notification state:', error);
+      toast({
+        title: "Error",
+        description: "Failed to update notification",
         variant: "destructive",
       });
     }
@@ -100,7 +150,9 @@ export const NotificationCenter: React.FC = () => {
           unreadCount={unreadCount}
           loading={loading}
           onMarkAllAsRead={handleMarkAllAsRead}
+          onMarkAllAsUnread={handleMarkAllAsUnread}
           onNotificationClick={handleNotificationClick}
+          onToggleReadState={handleToggleReadState}
           onClose={handleClose}
         />
       </PopoverContent>

--- a/src/components/notifications/NotificationDropdown.tsx
+++ b/src/components/notifications/NotificationDropdown.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
-import { CheckCheck, Loader2 } from 'lucide-react';
+import { BellDot, CheckCheck, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import { NotificationItem } from './NotificationItem';
 import { Notification } from '@/hooks/useNotifications';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface NotificationDropdownProps {
   notifications: Notification[];
   unreadCount: number;
   loading: boolean;
   onMarkAllAsRead: () => void;
+  onMarkAllAsUnread: () => void;
   onNotificationClick: (notification: Notification) => void;
+  onToggleReadState: (notification: Notification) => void;
   onClose: () => void;
 }
 
@@ -21,80 +24,127 @@ export const NotificationDropdown: React.FC<NotificationDropdownProps> = ({
   unreadCount,
   loading,
   onMarkAllAsRead,
+  onMarkAllAsUnread,
   onNotificationClick,
+  onToggleReadState,
   onClose,
 }) => {
+  const hasNotifications = notifications.length > 0;
+  const hasUnread = unreadCount > 0;
+  const hasRead = notifications.some(notification => notification.is_read);
+
   return (
-    <Card className="w-80 shadow-lg border-0 animate-fade-in">
-      {/* Header */}
-      <div className="p-4 border-b border-border">
-        <div className="flex items-center justify-between">
-          <h3 className="font-semibold text-foreground">
-            Notifications
-            {unreadCount > 0 && (
-              <span className="ml-2 text-xs bg-forest-green/10 text-forest-green px-2 py-1 rounded-full">
-                {unreadCount} new
-              </span>
-            )}
-          </h3>
-          {unreadCount > 0 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onMarkAllAsRead}
-              disabled={loading}
-              className="text-forest-green hover:text-forest-green/80 h-auto p-1"
-            >
-              {loading ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
+    <TooltipProvider delayDuration={150}>
+      <Card className="w-80 shadow-lg border-0 animate-fade-in">
+        {/* Header */}
+        <div className="p-3 border-b border-border/60 bg-muted/40">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <h3 className="font-semibold text-sm text-foreground">Notifications</h3>
+              {hasUnread ? (
+                <span className="text-xs bg-forest-green/10 text-forest-green px-2 py-0.5 rounded-full">
+                  {unreadCount} new
+                </span>
               ) : (
-                <CheckCheck className="w-4 h-4" />
+                <span className="text-xs text-muted-foreground">All caught up</span>
               )}
-              <span className="ml-1 text-xs">Mark all read</span>
-            </Button>
-          )}
-        </div>
-      </div>
-
-      {/* Notifications List */}
-      <ScrollArea className="h-80">
-        {notifications.length === 0 ? (
-          <div className="p-8 text-center text-muted-foreground">
-            <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-muted flex items-center justify-center">
-              <CheckCheck className="w-6 h-6" />
             </div>
-            <p className="text-sm font-medium mb-1">All caught up!</p>
-            <p className="text-xs">No new notifications to show.</p>
+            {hasNotifications && (
+              <div className="flex items-center gap-1">
+                {hasUnread && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={onMarkAllAsRead}
+                        disabled={loading}
+                        className="h-8 w-8 text-forest-green hover:text-forest-green/80"
+                        aria-label="Mark all as read"
+                      >
+                        {loading ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <CheckCheck className="w-4 h-4" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Mark all as read</TooltipContent>
+                  </Tooltip>
+                )}
+                {hasRead && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={onMarkAllAsUnread}
+                        disabled={loading}
+                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        aria-label="Mark all as unread"
+                      >
+                        {loading ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <BellDot className="w-4 h-4" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Mark all as unread</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            )}
           </div>
-        ) : (
-          <div className="divide-y divide-border">
-            {notifications.map((notification, index) => (
-              <NotificationItem
-                key={notification.id}
-                notification={notification}
-                onClick={onNotificationClick}
-              />
-            ))}
-          </div>
-        )}
-      </ScrollArea>
+        </div>
 
-      {/* Footer */}
-      {notifications.length > 0 && (
-        <>
-          <Separator />
-          <div className="p-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onClose}
-              className="w-full text-muted-foreground hover:text-foreground"
-            >
-              View all notifications
-            </Button>
-          </div>
-        </>
-      )}
-    </Card>
+        {/* Notifications List */}
+        <ScrollArea className="h-80">
+          {loading && !hasNotifications ? (
+            <div className="p-8 flex flex-col items-center justify-center text-muted-foreground space-y-3">
+              <Loader2 className="w-6 h-6 animate-spin" />
+              <p className="text-sm font-medium">Loading notifications...</p>
+            </div>
+          ) : !hasNotifications ? (
+            <div className="p-8 text-center text-muted-foreground">
+              <div className="w-12 h-12 mx-auto mb-3 rounded-full bg-muted flex items-center justify-center">
+                <CheckCheck className="w-6 h-6" />
+              </div>
+              <p className="text-sm font-medium mb-1">All caught up!</p>
+              <p className="text-xs">No notifications yet. We'll keep you posted.</p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2 p-3">
+              {notifications.map(notification => (
+                <NotificationItem
+                  key={notification.id}
+                  notification={notification}
+                  onClick={onNotificationClick}
+                  onToggleRead={onToggleReadState}
+                  disabled={loading}
+                />
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+
+        {/* Footer */}
+        {hasNotifications && (
+          <>
+            <Separator />
+            <div className="p-3">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onClose}
+                className="w-full text-muted-foreground hover:text-foreground"
+              >
+                View all notifications
+              </Button>
+            </div>
+          </>
+        )}
+      </Card>
+    </TooltipProvider>
   );
 };

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { 
-  Megaphone, 
-  FileText, 
-  Bot, 
-  Link, 
-  HelpCircle, 
-  Users, 
+import {
+  Megaphone,
+  FileText,
+  Bot,
+  Link,
+  HelpCircle,
+  Users,
   BarChart3,
-  Circle
+  Circle,
+  BellDot,
+  Check
 } from 'lucide-react';
 import { Notification } from '@/hooks/useNotifications';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface NotificationItemProps {
   notification: Notification;
   onClick: (notification: Notification) => void;
+  onToggleRead: (notification: Notification) => void;
+  disabled?: boolean;
 }
 
 const getNotificationIcon = (type: string) => {
@@ -38,88 +45,142 @@ const getNotificationIcon = (type: string) => {
   }
 };
 
-const getPriorityColor = (priority: string) => {
-  switch (priority) {
-    case 'high':
-      return 'text-destructive';
-    case 'medium':
-      return 'text-forest-green';
-    case 'low':
-      return 'text-muted-foreground';
-    default:
-      return 'text-muted-foreground';
+const getPriorityBadge = (priority: string) => {
+  if (priority === 'high') {
+    return (
+      <Badge className="bg-destructive/10 text-destructive border-transparent text-[10px] uppercase tracking-wide">
+        High priority
+      </Badge>
+    );
   }
+
+  if (priority === 'medium') {
+    return (
+      <Badge className="bg-forest-green/10 text-forest-green border-transparent text-[10px] uppercase tracking-wide">
+        Medium priority
+      </Badge>
+    );
+  }
+
+  return null;
+};
+
+const getIconAccentClass = (notification: Notification) => {
+  if (notification.priority === 'high') {
+    return 'bg-destructive/10 text-destructive';
+  }
+
+  if (!notification.is_read) {
+    return 'bg-forest-green/10 text-forest-green';
+  }
+
+  return 'bg-muted text-muted-foreground';
 };
 
 export const NotificationItem: React.FC<NotificationItemProps> = ({
   notification,
   onClick,
+  onToggleRead,
+  disabled,
 }) => {
+  const priorityBadge = getPriorityBadge(notification.priority);
+
   const handleClick = () => {
     onClick(notification);
   };
 
-  const timeAgo = formatDistanceToNow(new Date(notification.created_at), { 
-    addSuffix: true 
+  const handleToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onToggleRead(notification);
+  };
+
+  const timeAgo = formatDistanceToNow(new Date(notification.created_at), {
+    addSuffix: true
   });
 
   return (
     <div
       onClick={handleClick}
       className={`
-        group p-4 cursor-pointer transition-all duration-200
-        hover:bg-muted/50 border-l-4
-        ${notification.is_read 
-          ? 'border-l-transparent bg-background' 
-          : 'border-l-forest-green bg-forest-green/5'
+        group relative p-3 cursor-pointer transition-all duration-200
+        rounded-xl border
+        ${notification.is_read
+          ? 'border-transparent bg-background hover:border-border'
+          : 'border-forest-green/30 bg-forest-green/5 hover:bg-forest-green/10'
         }
       `}
     >
-      <div className="flex items-start space-x-3">
+      <div className="flex items-start gap-3">
         {/* Icon */}
         <div className={`
-          flex-shrink-0 p-2 rounded-full 
-          ${notification.is_read ? 'bg-muted' : 'bg-forest-green/10'}
-          ${getPriorityColor(notification.priority)}
+          flex-shrink-0 p-2 rounded-lg transition-colors shadow-sm
+          ${getIconAccentClass(notification)}
         `}>
           {getNotificationIcon(notification.notification_type)}
         </div>
 
         {/* Content */}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-start justify-between">
-            <div className="flex-1">
-              <h4 className={`
-                text-sm font-medium leading-tight
-                ${notification.is_read ? 'text-muted-foreground' : 'text-foreground'}
-              `}>
-                {notification.title}
-              </h4>
-              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+        <div className="flex-1 min-w-0 space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 space-y-1">
+              <div className="flex items-center gap-2">
+                <h4 className={`
+                  text-sm font-semibold leading-tight truncate
+                  ${notification.is_read ? 'text-muted-foreground' : 'text-foreground'}
+               `}>
+                  {notification.title}
+                </h4>
+                {!notification.is_read && (
+                  <span className="h-2 w-2 rounded-full bg-forest-green" aria-hidden="true" />
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground line-clamp-2">
                 {notification.message}
               </p>
               {notification.content_title && (
-                <p className="text-xs font-medium text-forest-green mt-1">
+                <p className="text-xs font-medium text-forest-green/90">
                   {notification.content_title}
                 </p>
               )}
             </div>
-            
-            {!notification.is_read && (
-              <div className="w-2 h-2 bg-forest-green rounded-full flex-shrink-0 ml-2 mt-1"></div>
-            )}
+
+            <div className="flex flex-col items-end gap-1">
+              <span className="text-xs text-muted-foreground">{timeAgo}</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleToggle}
+                    disabled={disabled}
+                    className={`
+                      h-7 w-7 transition-colors
+                      ${notification.is_read
+                        ? 'text-muted-foreground hover:text-forest-green'
+                        : 'text-forest-green hover:text-forest-green/80'
+                      }
+                    `}
+                    aria-label={notification.is_read ? 'Mark as unread' : 'Mark as read'}
+                  >
+                    {notification.is_read ? (
+                      <BellDot className="w-4 h-4" />
+                    ) : (
+                      <Check className="w-4 h-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {notification.is_read ? 'Mark as unread' : 'Mark as read'}
+                </TooltipContent>
+              </Tooltip>
+            </div>
           </div>
 
-          <div className="flex items-center justify-between mt-2">
-            <span className="text-xs text-muted-foreground">
-              {timeAgo}
-            </span>
-            {notification.priority === 'high' && (
-              <span className="text-xs font-medium text-destructive bg-destructive/10 px-2 py-1 rounded">
-                High Priority
-              </span>
-            )}
-          </div>
+          {priorityBadge && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {priorityBadge}
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- extend the notification hook with helpers to mark individual or all notifications as read or unread
- wire the new actions into the notification center with updated toasts and dropdown controls
- refresh the dropdown and item UI with compact styling and quick toggle buttons for individual notifications

## Testing
- `npm run lint` *(fails: pre-existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cceaf4f0bc83248d6c936c1134cb6e