### PR TITLE
Ensure client portal popups are scrollable

### DIFF
--- a/src/components/client-portal/AnnouncementCard.tsx
+++ b/src/components/client-portal/AnnouncementCard.tsx
@@ -39,14 +39,14 @@ const AnnouncementCard: React.FC<AnnouncementCardProps> = ({
           <p className="text-xs text-slate-gray dark:text-slate-400">{date}</p>
         </div>
       </DialogTrigger>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         <div className="mt-2 space-y-2">
-          {summary && <p className="text-sm text-slate-gray dark:text-slate-300">{summary}</p>}
+          {summary && <p className="text-sm text-slate-gray dark:text-slate-300 break-words">{summary}</p>}
           {content && (
-            <p className="text-sm text-slate-700 dark:text-slate-200 whitespace-pre-wrap">{content}</p>
+            <p className="text-sm text-slate-700 dark:text-slate-200 whitespace-pre-wrap break-words">{content}</p>
           )}
           {url && (
             <Button

--- a/src/components/client-portal/PerformanceMetricCard.tsx
+++ b/src/components/client-portal/PerformanceMetricCard.tsx
@@ -190,9 +190,9 @@ const PerformanceMetricCard = ({ report }: PerformanceMetricCardProps) => {
         </Card>
       </DialogTrigger>
 
-      <DialogContent className="max-w-3xl">
+      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
-          <DialogTitle className="flex items-center justify-between gap-2 text-forest-green">
+          <DialogTitle className="flex flex-wrap items-center justify-between gap-2 text-forest-green">
             <span>{report?.name || 'Performance Report'}</span>
             <Badge variant="outline" className="bg-forest-green/10 text-forest-green">
               {kpis.length} KPI{kpis.length === 1 ? '' : 's'}

--- a/src/components/client-portal/SessionDetailsDialog.tsx
+++ b/src/components/client-portal/SessionDetailsDialog.tsx
@@ -41,7 +41,7 @@ const SessionDetailsDialog: React.FC<SessionDetailsDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5 text-forest-green" />


### PR DESCRIPTION
## Summary
- add max-height and overflow handling to the client portal dialogs for sessions, performance metrics, and announcements so long content can scroll on all devices
- improve responsiveness by allowing performance metric headers to wrap and preventing announcement text from overflowing narrow viewports

## Testing
- npm run lint *(fails: existing lint violations throughout the project unrelated to these dialog updates)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb23f77a083249e1e8540c16c47e3