### PR TITLE
Update Hub Experience menu label to HUB »

### DIFF
--- a/src/utils/simpleMenuUtils.ts
+++ b/src/utils/simpleMenuUtils.ts
@@ -15,7 +15,7 @@ export class SimpleMenuManager {
       { label: 'Reviews', path: '#reviews', isActive: false, isExternal: false },
       { label: 'Team', path: '#team', isActive: false, isExternal: false },
       { label: 'Contact', path: '#contact', isActive: false, isExternal: false },
-      { label: 'Hub Experience', path: '/client-demo', isActive: false, isExternal: false }
+      { label: 'HUB »', path: '/client-demo', isActive: false, isExternal: false }
     ];
   }
 


### PR DESCRIPTION
## Summary
- update the public navigation menu label for the hub experience to display "HUB »"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f7a954d48324be10412b09d69593