### PR TITLE
Update client portal widget titles to rooted green

### DIFF
--- a/src/components/client-portal/AiToolCard.tsx
+++ b/src/components/client-portal/AiToolCard.tsx
@@ -13,7 +13,7 @@ const AiToolCard: React.FC<AiToolCardProps> = ({ title, url, comments }) => {
       <div className="flex items-start justify-between mb-2">
         <div className="flex items-center gap-2">
           <Bot className="h-4 w-4 text-forest-green dark:text-sage" />
-          <span className="text-sm font-medium text-black dark:text-sage">{title}</span>
+          <span className="text-sm font-medium text-forest-green dark:text-sage">{title}</span>
         </div>
         {url && <ExternalLink className="h-3 w-3 text-slate-gray dark:text-slate-300" />}
       </div>

--- a/src/components/client-portal/AnnouncementCard.tsx
+++ b/src/components/client-portal/AnnouncementCard.tsx
@@ -31,7 +31,7 @@ const AnnouncementCard: React.FC<AnnouncementCardProps> = ({
       <DialogTrigger asChild>
         <div className="py-2 border-b last:border-b-0 cursor-pointer transition-transform duration-200 ease-out hover:translate-x-1">
           <div className="flex items-center justify-between mb-1">
-            <p className="text-sm font-medium text-black dark:text-slate-200">{title}</p>
+            <p className="text-sm font-medium text-forest-green dark:text-sage">{title}</p>
             {status && (
               <Badge className="bg-forest-green/10 text-forest-green">{status}</Badge>
             )}
@@ -41,7 +41,7 @@ const AnnouncementCard: React.FC<AnnouncementCardProps> = ({
       </DialogTrigger>
       <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
-          <DialogTitle className="text-black">{title}</DialogTitle>
+          <DialogTitle className="text-forest-green dark:text-sage">{title}</DialogTitle>
         </DialogHeader>
         <div className="mt-2 space-y-2">
           {summary && <p className="text-sm text-slate-gray dark:text-slate-300 break-words">{summary}</p>}

--- a/src/components/client-portal/AppCard.tsx
+++ b/src/components/client-portal/AppCard.tsx
@@ -31,7 +31,7 @@ const AppCard: React.FC<AppCardProps> = ({ app, isDemo = false }) => {
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-2">
             <Smartphone className="h-5 w-5 text-forest-green" />
-            <CardTitle className="text-lg text-black group-hover:text-forest-green transition-colors">
+            <CardTitle className="text-lg text-forest-green dark:text-sage transition-colors">
               {app.name}
             </CardTitle>
           </div>

--- a/src/components/client-portal/EnhancedCoachingCard.tsx
+++ b/src/components/client-portal/EnhancedCoachingCard.tsx
@@ -115,7 +115,7 @@ const EnhancedCoachingCard: React.FC<EnhancedCoachingCardProps> = ({
 
           {/* Session Header */}
           <div className="mb-3">
-            <h4 className="font-medium text-foreground mb-1">
+            <h4 className="font-medium text-forest-green dark:text-sage mb-1">
               {session.topic}
             </h4>
             {session.description && (

--- a/src/components/client-portal/PerformanceMetricCard.tsx
+++ b/src/components/client-portal/PerformanceMetricCard.tsx
@@ -119,7 +119,7 @@ const PerformanceMetricCard = ({ report }: PerformanceMetricCardProps) => {
         <Card className="group relative h-full cursor-pointer border-forest-green/30 bg-gradient-to-br from-background to-muted/30 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-forest-green/60 hover:shadow-lg hover:shadow-forest-green/20 focus:outline-none focus:ring-2 focus:ring-forest-green/40">
           <CardHeader className="space-y-1">
             <div className="flex items-start justify-between gap-2">
-              <CardTitle className="text-lg font-semibold text-black">
+              <CardTitle className="text-lg font-semibold text-forest-green dark:text-sage">
                 {report?.name || 'Performance Report'}
               </CardTitle>
               <Badge variant="outline" className="bg-forest-green/10 text-forest-green">
@@ -138,7 +138,7 @@ const PerformanceMetricCard = ({ report }: PerformanceMetricCardProps) => {
                   return (
                     <div key={`${kpi.name}-${index}`} className="space-y-1.5">
                       <div className="flex items-center justify-between text-sm">
-                        <span className="text-muted-foreground">
+                        <span className="text-forest-green dark:text-sage">
                           {kpi.name || `Metric ${index + 1}`}
                         </span>
                         <span className="font-semibold text-forest-green">
@@ -192,7 +192,7 @@ const PerformanceMetricCard = ({ report }: PerformanceMetricCardProps) => {
 
       <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
-          <DialogTitle className="flex flex-wrap items-center justify-between gap-2 text-black">
+          <DialogTitle className="flex flex-wrap items-center justify-between gap-2 text-forest-green dark:text-sage">
             <span>{report?.name || 'Performance Report'}</span>
             <Badge variant="outline" className="bg-forest-green/10 text-forest-green">
               {kpis.length} KPI{kpis.length === 1 ? '' : 's'}

--- a/src/components/client-portal/ResourceCard.tsx
+++ b/src/components/client-portal/ResourceCard.tsx
@@ -17,7 +17,7 @@ const ResourceCard: React.FC<ResourceCardProps> = ({ title, type, href }) => {
       className="block p-3 rounded-lg border border-sage/20 dark:border-sage/30 hover:shadow-lg hover:-translate-y-0.5 dark:hover:bg-sage/10 focus:outline-none focus:ring-2 focus:ring-forest-green transition-all duration-200"
     >
       <div className="flex items-center justify-between mb-2">
-        <p className="text-sm font-medium text-black dark:text-sage">{title}</p>
+        <p className="text-sm font-medium text-forest-green dark:text-sage">{title}</p>
         <Badge className="bg-sage/20 dark:bg-sage/30 text-forest-green dark:text-sage">{type}</Badge>
       </div>
       <div className="text-sm text-forest-green dark:text-sage inline-flex items-center">

--- a/src/components/client-portal/SessionDetailsDialog.tsx
+++ b/src/components/client-portal/SessionDetailsDialog.tsx
@@ -53,10 +53,10 @@ const SessionDetailsDialog: React.FC<SessionDetailsDialogProps> = ({
           {/* Session Header */}
           <div className="space-y-3">
             <div className="flex items-start justify-between">
-              <h3 className="text-xl font-semibold text-foreground">
+              <h3 className="text-xl font-semibold text-forest-green dark:text-sage">
                 {session.topic}
               </h3>
-              <Badge 
+              <Badge
                 variant="secondary" 
                 className={`${statusConfig.bgColor} ${statusConfig.textColor} ${statusConfig.borderColor} ${statusConfig.animate || ''}`}
               >
@@ -138,7 +138,7 @@ const SessionDetailsDialog: React.FC<SessionDetailsDialogProps> = ({
                     </AvatarFallback>
                   </Avatar>
                   <div className="flex-1">
-                    <p className="font-medium text-foreground">
+                    <p className="font-medium text-forest-green dark:text-sage">
                       {leaderName || 'Session Leader'}
                     </p>
                     {session.leader_email && (

--- a/src/components/client-portal/UsefulLinkCard.tsx
+++ b/src/components/client-portal/UsefulLinkCard.tsx
@@ -15,7 +15,7 @@ const UsefulLinkCard: React.FC<UsefulLinkCardProps> = ({ title, url }) => {
       className="block p-3 rounded-lg border border-sage/20 dark:border-sage/30 hover:shadow-lg hover:-translate-y-0.5 dark:hover:bg-sage/10 focus:outline-none focus:ring-2 focus:ring-forest-green transition-all duration-200"
     >
       <div className="flex items-center justify-between">
-        <p className="text-sm font-medium text-black dark:text-sage">{title}</p>
+        <p className="text-sm font-medium text-forest-green dark:text-sage">{title}</p>
         <ArrowRight className="h-4 w-4 text-forest-green dark:text-sage" />
       </div>
     </a>


### PR DESCRIPTION
## Summary
- apply rooted green styling to performance metric cards and KPI labels across client dashboards
- update announcement, resource, AI tool, app, and quick access link titles to consistently use the rooted green accent
- align session widgets and dialogs with the rooted green treatment while keeping section headers in black

## Testing
- npm run lint *(fails: existing configuration is missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d70c445aec83249dbb62c7c16d767c