### PR TITLE
Adjust CTA placement on client demo portal

### DIFF
--- a/src/pages/ClientDemoPortal.tsx
+++ b/src/pages/ClientDemoPortal.tsx
@@ -270,10 +270,10 @@ const ClientDemoPortal: React.FC = () => {
               </div>
               
               {/* Right Sidebar */}
-              <div className="lg:col-span-4 space-y-6">
+              <div className="lg:col-span-4 space-y-6 flex flex-col">
 
                 {/* Call to Action Card */}
-                <Card className="bg-gradient-to-br from-forest-green/15 to-forest-green/5 border-forest-green/20">
+                <Card className="order-last lg:order-first bg-gradient-to-br from-forest-green/15 to-forest-green/5 border-forest-green/20">
                   <CardHeader>
                     <CardTitle className="text-black">Ready to Activate Your Hub?</CardTitle>
                     <CardDescription>


### PR DESCRIPTION
## Summary
- ensure the client demo sidebar uses a column flex layout so content can be reordered
- move the "Ready to Activate Your Hub?" card to the bottom on mobile while keeping its desktop position

## Testing
- npm run build *(fails: vite not found prior to dependency installation)*
- npm install *(fails: peer dependency conflict between date-fns and react-day-picker)*

------
https://chatgpt.com/codex/tasks/task_e_68d715c623f88324b1b3e04537be805a