### PR TITLE
Ensure Artifacts page scrolls to top on load

### DIFF
--- a/src/pages/Artifacts.tsx
+++ b/src/pages/Artifacts.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -191,6 +191,10 @@ const aiLevels: AILevel[] = [
 
 const Artifacts = () => {
   const [openLevels, setOpenLevels] = useState<Set<number>>(new Set([1]));
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, []);
 
   const toggleLevel = (level: number) => {
     const newOpenLevels = new Set(openLevels);


### PR DESCRIPTION
## Summary
- ensure the Artifacts page scroll position resets to the top when the route loads so users begin at the header

## Testing
- npm install (fails: peer dependency conflict between date-fns and react-day-picker)
- npm install --legacy-peer-deps


------
https://chatgpt.com/codex/tasks/task_e_68d7256c02ac8324805cdf79de58450f