### PR TITLE
Allow admins to reach public landing pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,18 +117,18 @@ const AppLoadingWrapper = ({ children }: { children: React.ReactNode }) => {
   return <>{children}</>;
 };
 
-// Global admin redirect hook - only redirect from root and auth pages
+// Global admin redirect hook - keep admins out of public auth-only pages
 const useAdminRedirect = () => {
   const { user, authReady, userRole } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   
   React.useEffect(() => {
-    // Only redirect admins from root (/) or auth (/auth) pages, allow access to client portals
-    const shouldRedirect = authReady && 
-      user && 
-      userRole === 'Admin' && 
-      (location.pathname === '/' || location.pathname === '/auth');
+    // Only redirect admins from auth (/auth) page, allow access to marketing/client pages
+    const shouldRedirect = authReady &&
+      user &&
+      userRole === 'Admin' &&
+      location.pathname === '/auth';
       
     if (shouldRedirect) {
       console.log('🔄 Admin redirect from', location.pathname, 'to /admin');
@@ -146,13 +146,13 @@ const AppContent = () => {
       <Route path="/" element={<Index />} />
       <Route path="/auth" element={<Auth />} />
       <Route path="/artifacts" element={<Artifacts />} />
-      <Route 
-        path="/client-demo" 
+      <Route
+        path="/client-demo"
         element={
-          <PublicOnlyGuard>
+          <PublicOnlyGuard allowedRoles={["Admin"]}>
             <ClientDemoPortal />
           </PublicOnlyGuard>
-        } 
+        }
       />
       
       {/* Protected routes with role requirements */}

--- a/src/components/PublicOnlyGuard.tsx
+++ b/src/components/PublicOnlyGuard.tsx
@@ -5,13 +5,15 @@ import { useAuth } from '@/hooks/useAuth';
 interface PublicOnlyGuardProps {
   children: React.ReactNode;
   redirectTo?: string;
+  allowedRoles?: string[];
 }
 
-const PublicOnlyGuard: React.FC<PublicOnlyGuardProps> = ({ 
-  children, 
-  redirectTo = '/' 
+const PublicOnlyGuard: React.FC<PublicOnlyGuardProps> = ({
+  children,
+  redirectTo = '/',
+  allowedRoles = []
 }) => {
-  const { user, authReady } = useAuth();
+  const { user, authReady, userRole } = useAuth();
 
   // Wait for auth to be ready before making decisions
   if (!authReady) {
@@ -20,6 +22,9 @@ const PublicOnlyGuard: React.FC<PublicOnlyGuardProps> = ({
 
   // If user is authenticated, redirect them away
   if (user) {
+    if (userRole && allowedRoles.includes(userRole)) {
+      return <>{children}</>;
+    }
     return <Navigate to={redirectTo} replace />;
   }
 


### PR DESCRIPTION
## Summary
- stop redirecting admins away from the marketing home page so they can browse the public site
- update the client demo route guard to allow signed-in admins while still blocking other authenticated roles

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d750c1461883248a8c774fe4d95051