### PR TITLE
Adjust client portal headings for dark mode

### DIFF
--- a/src/components/client-portal/FAQSection.tsx
+++ b/src/components/client-portal/FAQSection.tsx
@@ -36,7 +36,7 @@ const FAQSection: React.FC<FAQSectionProps> = ({ faqs, isDemo = false }) => {
   return (
     <div className="animate-slide-up-delayed-5" data-demo={isDemo ? 'true' : 'false'}>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-semibold text-black">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
           Frequently Asked Questions
         </h2>
         <Badge
@@ -57,7 +57,7 @@ const FAQSection: React.FC<FAQSectionProps> = ({ faqs, isDemo = false }) => {
                   className="border rounded-lg shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg hover:border-forest-green/40"
                 >
                   <AccordionTrigger className="px-4 hover:no-underline">
-                    <div className="flex items-center gap-2 text-black">
+                    <div className="flex items-center gap-2 text-slate-900 dark:text-white">
                       <HelpCircle className="h-5 w-5 text-forest-green" />
                       <span className="font-semibold text-lg">{category}</span>
                       <Badge
@@ -78,7 +78,7 @@ const FAQSection: React.FC<FAQSectionProps> = ({ faqs, isDemo = false }) => {
                         >
                           <AccordionTrigger className="text-left hover:no-underline">
                             <div className="flex-1 pr-4">
-                              <div className="font-medium text-base text-black">{faq.question}</div>
+                              <div className="font-medium text-base text-slate-900 dark:text-white">{faq.question}</div>
                               {faq.goal && (
                                 <div className="text-sm text-forest-green mt-1">
                                   Goal: {faq.goal}

--- a/src/components/client-portal/UserAnalyticsCard.tsx
+++ b/src/components/client-portal/UserAnalyticsCard.tsx
@@ -162,7 +162,7 @@ export const UserAnalyticsCard = ({ companyId }: UserAnalyticsCardProps) => {
       <CardHeader>
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-2">
-            <CardTitle className="flex items-center gap-2 text-black">
+            <CardTitle className="flex items-center gap-2 text-slate-900 dark:text-white">
               <BarChart3 className="h-5 w-5 text-forest-green" />
               User Analytics
             </CardTitle>
@@ -336,7 +336,7 @@ export const UserAnalyticsCard = ({ companyId }: UserAnalyticsCardProps) => {
                 {/* Member Management Section */}
                 <div className="space-y-4">
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <h3 className="text-lg font-semibold text-black">Member Management</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Member Management</h3>
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end w-full sm:w-auto">
                       <Button
                         variant="outline"

--- a/src/pages/ClientDemoPortal.tsx
+++ b/src/pages/ClientDemoPortal.tsx
@@ -142,7 +142,7 @@ const ClientDemoPortal: React.FC = () => {
                 {/* At-a-Glance Summary */}
                 <Card className="bg-gradient-to-br from-forest-green/5 to-sage/10 border-forest-green/20 animate-fade-in">
                   <CardHeader>
-                    <CardTitle className="text-black">Dashboard Overview</CardTitle>
+                    <CardTitle className="text-slate-900 dark:text-white">Dashboard Overview</CardTitle>
                     <CardDescription>Sample intelligence from the RootedAI client hub ecosystem</CardDescription>
                   </CardHeader>
                   <CardContent>
@@ -175,7 +175,7 @@ const ClientDemoPortal: React.FC = () => {
                 {content.kpis.length > 0 && (
                   <div className="animate-slide-up">
                     <div className="flex items-center justify-between mb-4">
-                      <h2 className="text-2xl font-semibold text-black">Performance Metrics</h2>
+                      <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Performance Metrics</h2>
                       <Badge variant="outline" className="text-forest-green border-forest-green/30">Sample Hub Data</Badge>
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
@@ -198,7 +198,7 @@ const ClientDemoPortal: React.FC = () => {
                 {content.announcements.length > 0 && (
                   <div className="animate-slide-up-delayed">
                     <div className="flex items-center justify-between mb-4">
-                      <h2 className="text-2xl font-semibold text-black">Latest Updates</h2>
+                      <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Latest Updates</h2>
                       <div className="text-sm bg-forest-green/10 text-forest-green px-2 py-1 rounded-full">
                         {content.announcements.length} new
                       </div>
@@ -228,7 +228,7 @@ const ClientDemoPortal: React.FC = () => {
                 {content.resources.length > 0 && (
                   <div className="animate-slide-up-delayed-2">
                     <div className="flex items-center justify-between mb-4">
-                      <h2 className="text-2xl font-semibold text-black">Resource Library</h2>
+                      <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Resource Library</h2>
                       <div className="text-sm text-muted-foreground">{content.resources.length} available</div>
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -275,7 +275,7 @@ const ClientDemoPortal: React.FC = () => {
                 {/* Call to Action Card */}
                 <Card className="order-last lg:order-first bg-gradient-to-br from-forest-green/15 to-forest-green/5 border-forest-green/20">
                   <CardHeader>
-                    <CardTitle className="text-black">Ready to Activate Your Hub?</CardTitle>
+                    <CardTitle className="text-slate-900 dark:text-white">Ready to Activate Your Hub?</CardTitle>
                     <CardDescription>
                       Experience the full RootedAI client hub with personalized insights engineered for
                       your team.
@@ -294,7 +294,7 @@ const ClientDemoPortal: React.FC = () => {
                 {/* Coaching Sessions Widget */}
                 {content.coaching.length > 0 && (
                   <div className="animate-slide-left">
-                    <h3 className="text-lg font-semibold text-black mb-4">Upcoming Sessions</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Upcoming Sessions</h3>
                     <Suspense fallback={<Skeleton className="h-32 w-full" />}>
                       <EnhancedCoachingCard sessions={content.coaching} />
                     </Suspense>
@@ -304,7 +304,7 @@ const ClientDemoPortal: React.FC = () => {
                 {/* AI Tools Widget */}
                 {content.ai_tools.length > 0 && (
                   <div className="animate-slide-left-delayed">
-                    <h3 className="text-lg font-semibold text-black mb-4">AI Toolkit</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">AI Toolkit</h3>
                     <div className="space-y-3">
                       {content.ai_tools.slice(0, 3).map((tool: any, index: number) => (
                         <div key={tool.id} className="animate-spring-up" style={{ animationDelay: `${index * 0.1}s` }}>
@@ -335,7 +335,7 @@ const ClientDemoPortal: React.FC = () => {
                 {/* Apps Widget */}
                 {content.apps.length > 0 && (
                   <div className="animate-slide-left-delayed">
-                    <h3 className="text-lg font-semibold text-black mb-4">Available Apps</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Available Apps</h3>
                     <div className="space-y-3">
                       {content.apps.slice(0, 3).map((app: any, index: number) => (
                         <div key={app.id} className="animate-spring-up" style={{ animationDelay: `${index * 0.1}s` }}>
@@ -362,7 +362,7 @@ const ClientDemoPortal: React.FC = () => {
                 {/* Quick Links Widget */}
                 {content.useful_links.length > 0 && (
                   <div className="animate-slide-left-delayed">
-                    <h3 className="text-lg font-semibold text-black mb-4">Quick Access</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Quick Access</h3>
                     <div className="space-y-2">
                       {content.useful_links.slice(0, 4).map((link: any, index: number) => (
                         <div key={link.id} className="animate-fade-in" style={{ animationDelay: `${index * 0.1}s` }}>
@@ -424,7 +424,7 @@ const ClientDemoPortal: React.FC = () => {
         {/* Contact Footer */}
         <Card className="bg-gradient-to-r from-forest-green/5 to-sage/10 border-forest-green/20">
           <CardContent className="py-8 text-center">
-            <h3 className="text-xl font-semibold text-black mb-2">
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-white mb-2">
               Ready to Transform Your Business?
             </h3>
             <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">

--- a/src/pages/ClientPortal.tsx
+++ b/src/pages/ClientPortal.tsx
@@ -361,7 +361,7 @@ const ClientPortal: React.FC = () => {
                 {/* At-a-Glance Summary */}
                 <Card className="bg-gradient-to-br from-forest-green/5 to-sage/10 border-forest-green/20 animate-fade-in">
                   <CardHeader>
-                    <CardTitle className="text-black">Dashboard Overview</CardTitle>
+                    <CardTitle className="text-slate-900 dark:text-white">Dashboard Overview</CardTitle>
                     <CardDescription>Your personalized content summary</CardDescription>
                   </CardHeader>
                   <CardContent>
@@ -394,7 +394,7 @@ const ClientPortal: React.FC = () => {
                 {content.kpis.length > 0 && (
                   <div className="animate-slide-up">
                     <div className="flex items-center justify-between mb-4">
-                      <h2 className="text-2xl font-semibold text-black">Performance Metrics</h2>
+                      <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Performance Metrics</h2>
                       <div className="w-2 h-2 bg-forest-green rounded-full animate-pulse"></div>
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
@@ -417,7 +417,7 @@ const ClientPortal: React.FC = () => {
                 {content.announcements.length > 0 && (
                   <div className="animate-slide-up-delayed">
                     <div className="flex items-center justify-between mb-4">
-                      <h2 className="text-2xl font-semibold text-black">Latest Updates</h2>
+                      <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Latest Updates</h2>
                       <div className="text-sm bg-forest-green/10 text-forest-green px-2 py-1 rounded-full">
                         {content.announcements.length} new
                       </div>
@@ -456,7 +456,7 @@ const ClientPortal: React.FC = () => {
                 {content.resources.length > 0 && (
                   <div className="animate-slide-up-delayed-2">
                     <div className="flex items-center justify-between mb-4">
-                      <h2 className="text-2xl font-semibold text-black">Resource Library</h2>
+                      <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Resource Library</h2>
                       <div className="text-sm text-muted-foreground">{content.resources.length} available</div>
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -509,7 +509,7 @@ const ClientPortal: React.FC = () => {
                 {/* Coaching Sessions Widget */}
                 {content.coaching.length > 0 && (
                   <div className="animate-slide-left">
-                    <h3 className="text-lg font-semibold text-black mb-4">Upcoming Sessions</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Upcoming Sessions</h3>
                     <Suspense fallback={<Skeleton className="h-32 w-full" />}>
                       <EnhancedCoachingCard sessions={content.coaching} />
                     </Suspense>
@@ -519,7 +519,7 @@ const ClientPortal: React.FC = () => {
                 {/* AI Tools Widget */}
                 {content.ai_tools.length > 0 && (
                   <div className="animate-slide-left-delayed">
-                    <h3 className="text-lg font-semibold text-black mb-4">AI Toolkit</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">AI Toolkit</h3>
                     <div className="space-y-3">
                       {content.ai_tools.slice(0, 3).map((tool: any, index: number) => (
                         <div key={tool.id} className="animate-spring-up" style={{ animationDelay: `${index * 0.1}s` }}>
@@ -550,7 +550,7 @@ const ClientPortal: React.FC = () => {
                 {/* Apps Widget */}
                 {content.apps.length > 0 && (
                   <div className="animate-slide-left-delayed">
-                    <h3 className="text-lg font-semibold text-black mb-4">Available Apps</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Available Apps</h3>
                     <div className="space-y-3">
                       {content.apps.slice(0, 3).map((app: any, index: number) => (
                         <div key={app.id} className="animate-spring-up" style={{ animationDelay: `${index * 0.1}s` }}>
@@ -577,7 +577,7 @@ const ClientPortal: React.FC = () => {
                 {/* Quick Links Widget */}
                 {content.useful_links.length > 0 && (
                   <div className="animate-slide-left-delayed">
-                    <h3 className="text-lg font-semibold text-black mb-4">Quick Access</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Quick Access</h3>
                     <div className="space-y-2">
                       {content.useful_links.slice(0, 4).map((link: any, index: number) => (
                         <div key={link.id} className="animate-fade-in" style={{ animationDelay: `${index * 0.1}s` }}>


### PR DESCRIPTION
## Summary
- align client portal and demo widget headings with theme-aware colors that match the home page's dark mode treatment
- update FAQ and analytics components to replace hard-coded black text with light/dark variants for improved contrast

## Testing
- npm run lint *(fails: missing @eslint/js package prior to install)*

------
https://chatgpt.com/codex/tasks/task_e_68d7528bcec08324a8607923754c6083