### PR TITLE
Hardcode upcoming session times on client demo

### DIFF
--- a/src/pages/ClientDemoPortal.tsx
+++ b/src/pages/ClientDemoPortal.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useMemo } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
@@ -26,6 +26,29 @@ const EnhancedCoachingCard = React.lazy(
 
 const ClientDemoPortal: React.FC = () => {
   const { content, loading, error, refresh } = usePublicPortalContent();
+
+  const demoCoachingSessions = useMemo(() => {
+    if (!content.coaching || content.coaching.length === 0) {
+      return content.coaching;
+    }
+
+    const now = new Date();
+    const future = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const minutes = future.getMinutes();
+
+    if (minutes >= 30) {
+      future.setHours(future.getHours() + 1);
+    }
+
+    future.setMinutes(0, 0, 0);
+
+    const roundedFutureIso = future.toISOString();
+
+    return content.coaching.map((session: any) => ({
+      ...session,
+      session_date: roundedFutureIso
+    }));
+  }, [content.coaching]);
 
   // Handle content error
   if (error && !loading) {
@@ -292,11 +315,11 @@ const ClientDemoPortal: React.FC = () => {
                 </Card>
 
                 {/* Coaching Sessions Widget */}
-                {content.coaching.length > 0 && (
+                {demoCoachingSessions && demoCoachingSessions.length > 0 && (
                   <div className="animate-slide-left">
                     <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Upcoming Sessions</h3>
                     <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-                      <EnhancedCoachingCard sessions={content.coaching} />
+                      <EnhancedCoachingCard sessions={demoCoachingSessions} />
                     </Suspense>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- ensure the Client Demo portal hardcodes upcoming session dates 24 hours into the future
- round the generated session timestamp to the nearest hour in the viewer's timezone before rendering

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d76f512bb08324819349a854cc4efe