### PR TITLE
Animate HUB text in header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -147,7 +147,7 @@ const Header = () => {
                   to="/client-demo"
                   className="flex items-center space-x-1 text-slate-gray hover:text-forest-green transition-colors duration-200 font-medium"
                 >
-                  <span>HUB</span>
+                  <span className="text-forest-green animate-pulse">HUB</span>
                   <span className="text-forest-green animate-pulse">»</span>
                 </Link>
               )}
@@ -178,7 +178,7 @@ const Header = () => {
                 }
                 const content = isHubLink ? (
                   <span className="inline-flex items-center gap-1">
-                    <span>HUB</span>
+                    <span className="text-forest-green animate-pulse">HUB</span>
                     <span className="text-forest-green animate-pulse">»</span>
                   </span>
                 ) : (
@@ -261,7 +261,7 @@ const Header = () => {
                   }
                   const content = isHubLink ? (
                     <span className="inline-flex items-center gap-1">
-                      <span>HUB</span>
+                      <span className="text-forest-green animate-pulse">HUB</span>
                       <span className="text-forest-green animate-pulse">»</span>
                     </span>
                   ) : (


### PR DESCRIPTION
## Summary
- add pulse animation and forest green color to the HUB label so it matches the animated arrow indicator in the header

## Testing
- npm install *(fails: dependency conflict between date-fns and react-day-picker peer requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e8c0eac883248c0b401fbda27817