### PR TITLE
Remove solid indicator dot from hero CTA

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -58,8 +58,8 @@ const Hero = () => {
               >
                 <span>Client Experience</span>
                 <span className="relative flex h-2 w-2 items-center justify-center" aria-hidden="true">
-                  <span className="absolute inline-flex h-full w-full rounded-full bg-white/70 opacity-70 shadow-[0_0_12px_rgba(255,255,255,0.6)] motion-safe:animate-ping" />
-                  <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-white shadow-[0_0_8px_rgba(255,255,255,0.9)]" />
+                  <span className="absolute inline-flex h-full w-full rounded-full border border-white/70 opacity-70 shadow-[0_0_12px_rgba(255,255,255,0.6)] motion-safe:animate-ping" />
+                  <span className="relative inline-flex h-1.5 w-1.5 rounded-full border border-white shadow-[0_0_8px_rgba(255,255,255,0.8)] bg-transparent" />
                 </span>
               </a>
             </Button>


### PR DESCRIPTION
## Summary
- replace the solid dot beside the Client Experience CTA with a bordered ring so the white dot is removed while keeping the pulse animation intact

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0194e9cfc832496c81b73cee5f952