### PR TITLE
Add dual pulsing indicators to Client Experience CTA

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -56,6 +56,10 @@ const Hero = () => {
                 href="/client-demo"
                 className="relative z-10 flex items-center gap-3 font-semibold tracking-wide"
               >
+                <span className="relative flex h-2 w-2 items-center justify-center" aria-hidden="true">
+                  <span className="absolute inline-flex h-full w-full rounded-full border border-white/70 opacity-70 shadow-[0_0_12px_rgba(255,255,255,0.6)] motion-safe:animate-ping" />
+                  <span className="relative inline-flex h-1.5 w-1.5 rounded-full border border-white shadow-[0_0_8px_rgba(255,255,255,0.8)] bg-transparent" />
+                </span>
                 <span>Client Experience</span>
                 <span className="relative flex h-2 w-2 items-center justify-center" aria-hidden="true">
                   <span className="absolute inline-flex h-full w-full rounded-full border border-white/70 opacity-70 shadow-[0_0_12px_rgba(255,255,255,0.6)] motion-safe:animate-ping" />


### PR DESCRIPTION
## Summary
- add a second pulsing indicator before the "Client Experience" CTA text so the animation appears on both sides

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e02d8f6ad08324bca69b315be252e1