### PR TITLE
Preserve scroll position across route changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { usePerformanceMonitor } from "@/hooks/usePerformanceMonitor";
 import { Button } from "@/components/ui/button";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { LoadingIcon } from "@/components/LoadingSpinner";
+import ScrollRestoration from "@/components/ScrollRestoration";
 
 import AuthGuard from "@/components/AuthGuard";
 import PublicOnlyGuard from "@/components/PublicOnlyGuard";
@@ -255,6 +256,7 @@ const App = () => {
               <Sonner />
               <BrowserRouter>
                 <AppLoadingWrapper>
+                  <ScrollRestoration />
                   <main id="main-content">
                     <AppContent />
                   </main>

--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+type LocationKey = string;
+
+const STORAGE_KEY = "rootedai:scroll-positions";
+
+const createLocationKey = (location: ReturnType<typeof useLocation>): LocationKey => {
+  return `${location.pathname}${location.search}${location.hash}`;
+};
+
+const readStoredPositions = () => {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {} as Record<LocationKey, number>;
+    }
+
+    const parsed = JSON.parse(raw) as Record<LocationKey, number>;
+    if (parsed && typeof parsed === "object") {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn("Failed to read scroll positions from storage", error);
+  }
+
+  return {} as Record<LocationKey, number>;
+};
+
+const persistPositions = (positions: Record<LocationKey, number>) => {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(positions));
+  } catch (error) {
+    console.warn("Failed to persist scroll positions", error);
+  }
+};
+
+export const ScrollRestoration: React.FC = () => {
+  const location = useLocation();
+  const locationKey = React.useMemo(
+    () => createLocationKey(location),
+    [location.pathname, location.search, location.hash],
+  );
+  const positionsRef = React.useRef<Record<LocationKey, number>>({});
+  const initializedRef = React.useRef(false);
+  const previousKeyRef = React.useRef<LocationKey | null>(null);
+
+  const savePosition = React.useCallback((key: LocationKey, value: number) => {
+    positionsRef.current[key] = value;
+    persistPositions(positionsRef.current);
+  }, []);
+
+  // Hydrate scroll positions from storage once on mount
+  React.useEffect(() => {
+    if (initializedRef.current) {
+      return;
+    }
+
+    positionsRef.current = readStoredPositions();
+    previousKeyRef.current = locationKey;
+    initializedRef.current = true;
+  }, [locationKey]);
+
+  // Persist the scroll position when navigating away from the page or closing the tab
+  React.useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (!initializedRef.current) {
+        return;
+      }
+
+      savePosition(locationKey, window.scrollY);
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener("pagehide", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("pagehide", handleBeforeUnload);
+    };
+  }, [locationKey, savePosition]);
+
+  React.useLayoutEffect(() => {
+    if (!initializedRef.current) {
+      return;
+    }
+
+    const previousKey = previousKeyRef.current;
+
+    if (previousKey && previousKey !== locationKey) {
+      savePosition(previousKey, window.scrollY);
+    }
+
+    const storedPosition = positionsRef.current[locationKey] ?? 0;
+
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: storedPosition, behavior: "auto" });
+    });
+
+    previousKeyRef.current = locationKey;
+  }, [locationKey, savePosition]);
+
+  return null;
+};
+
+export default ScrollRestoration;


### PR DESCRIPTION
## Summary
- add a ScrollRestoration component that persists scroll positions in session storage
- mount the scroll restoration helper within the app shell so routes restore to their previous position

## Testing
- npm run build *(fails: vite: not found)*
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e037d18f688324ba0409dc69c5b9fc